### PR TITLE
feat(packs/dotnet): add .NET convention pack

### DIFF
--- a/detection.toml
+++ b/detection.toml
@@ -5,6 +5,10 @@
 files = ["pyproject.toml", "setup.py", "requirements.txt"]
 pack = "python"
 
+[dotnet]
+files = ["*.sln", "*.csproj", "Directory.Packages.props"]
+pack = "dotnet"
+
 [supply-chain]
 files = [".github/workflows/*.yml", ".github/workflows/*.yaml"]
 pack = "supply-chain"

--- a/packs/dotnet/AGENTS.md
+++ b/packs/dotnet/AGENTS.md
@@ -1,0 +1,20 @@
+## .NET Conventions
+
+**Toolchain:** dotnet CLI (build, test, publish), NUnit (testing), coverlet (coverage), editorconfig (style enforcement).
+
+**Setup verification:** Before writing code, confirm: `dotnet --version` (>= 10.0). If a `Directory.Packages.props` exists, all package versions are managed centrally — never add `Version=` attributes to individual `PackageReference` entries.
+
+**Package management:** Use central package management via `Directory.Packages.props`. Add new packages with `dotnet add package <name>` then move the version to `Directory.Packages.props`. Use the private feed in `nuget.config` for internal packages — do not add alternative feeds without review.
+
+**Code style:** File-scoped namespaces (`namespace X;` not `namespace X { }`). Nullable reference types enabled. Follow `.editorconfig` rules. No `#pragma warning disable` unless the reason is documented inline.
+
+**Project structure:** Clean Architecture — `src/` contains Core (domain), Application (use cases), Infrastructure (external concerns), FunctionApp/API (entry point). `tst/` mirrors `src/` with UnitTests, IntegrationTests, and ComponentTests per layer.
+
+**Testing:** Tests live in `tst/`. Run with `dotnet test`. Use `coverlet.runsettings` for coverage configuration. Every error path needs a test. Use Moq for mocking. Name tests: `MethodName_Scenario_ExpectedResult`.
+
+**Acceptance criteria:**
+- [ ] `dotnet build` succeeds with zero warnings
+- [ ] `dotnet test` passes all unit and component tests
+- [ ] No `Version=` in individual `.csproj` files (central management only)
+- [ ] No unhandled error paths in new code
+- [ ] New public APIs have XML doc comments

--- a/packs/dotnet/CLAUDE.md
+++ b/packs/dotnet/CLAUDE.md
@@ -1,0 +1,7 @@
+## .NET — Claude Code
+
+Run tests with `dotnet test` from the solution root.
+
+If targeting a specific test project: `dotnet test tst/<ProjectName>/<ProjectName>.csproj`.
+
+Build the solution with `dotnet build <SolutionName>.sln`.

--- a/packs/dotnet/README.md
+++ b/packs/dotnet/README.md
@@ -1,0 +1,16 @@
+# .NET Convention Pack
+
+Mission-critical .NET conventions for Schuberg Philis projects.
+
+## What this activates
+
+- **Central package management** via `Directory.Packages.props`
+- **Clean Architecture** project layout (Core, Application, Infrastructure, entry point)
+- **NUnit + coverlet** for testing and coverage
+- **File-scoped namespaces** and nullable reference types
+
+## Auto-detected by
+
+- `*.sln`
+- `*.csproj`
+- `Directory.Packages.props`

--- a/packs/dotnet/manifest.toml
+++ b/packs/dotnet/manifest.toml
@@ -1,0 +1,13 @@
+[pack]
+name = "dotnet"
+description = "Mission-critical .NET: central package management, NUnit, coverlet, file-scoped namespaces — auditable, testable, safe for production"
+version = "1.0.0"
+authors = ["Schuberg Philis"]
+
+[detect]
+files = ["*.sln", "*.csproj", "Directory.Packages.props"]
+
+[targets]
+agents_md = true
+claude_md = true
+commands = false


### PR DESCRIPTION
Added dotnet pack with 
1. Clean Architecture conventions, 
2. Central package management, 
3. NUnit/coverlet testing
4. File-scoped namespace enforcement. Auto-detects on *.sln, *.csproj, or Directory.Packages.props.