### PR TITLE
Reframe docs around the Skills paradigm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # sbp-skills
 
-Mission-critical cognitive autonomy for Schuberg Philis engineering teams.
+> "Agents today are brilliant, but they lack expertise."
+> — Barry Zhang & Mahesh Murag, Anthropic — [AI Engineer Code Summit](https://www.youtube.com/watch?v=CEvIs9y1uog)
 
-Turn every AI coding agent into a coworker that thinks like a senior SBP engineer — challenging assumptions, reviewing for failure modes, and teaching mission-critical practices through daily interaction.
+The industry is converging on a single insight: **stop building specialized agents — build Skills instead.** Intelligence without domain expertise is entertainment. The difference between a mediocre agent and an extraordinary one isn't the model — it's the knowledge you feed it.
 
-Works with **Claude Code**, **GitHub Copilot**, and **OpenCode**. Compatible with [skills.sh](https://skills.sh) and the [agentskills.io](https://agentskills.io) standard — use your own skills alongside these.
+Skills are folders with markdown files that encode your workflows, your conventions, your hard-won expertise. One generic agent + the right skills beats dozens of specialized agents. This works across all AI coding tools — Claude Code, GitHub Copilot, OpenCode, and any agent that reads markdown from the filesystem.
+
+**sbp-skills is our skills library.** It turns every AI coding agent into a coworker that thinks like a senior SBP engineer — challenging assumptions, reviewing for failure modes, and teaching mission-critical practices through daily interaction. Same skills, every tool, one standard.
+
+Works with **Claude Code**, **GitHub Copilot**, and **OpenCode**. Compatible with [skills.sh](https://skills.sh) and the [agentskills.io](https://agentskills.io) standard.
 
 ---
 

--- a/WHY.md
+++ b/WHY.md
@@ -10,6 +10,21 @@ At Schuberg Philis, that's not acceptable.
 
 We deliver 100% customer satisfaction and 100% quality on systems that run healthcare, finance, energy, and government. Our engineers don't just build software — they plan, build, and run it. The same person who writes the code is the one who gets paged when it breaks. That creates a way of thinking that no AI model has been trained on.
 
+## The industry is catching up
+
+At the AI Engineer Code Summit, Anthropic's Barry Zhang and Mahesh Murag told the industry to stop building agents and start building Skills. Their computing stack analogy: models are processors, agent runtimes are operating systems, and skills are applications. The application layer is where domain expertise lives — and it's portable across tools.
+
+This isn't just an Anthropic idea. Claude Code, GitHub Copilot, and OpenCode all read markdown skills from the filesystem. The [agentskills.io](https://agentskills.io) spec is becoming the common format. Write a skill once, use it in every tool.
+
+Their three categories of skills map directly to what we've built:
+- **Foundational skills** — general capabilities (our baseline)
+- **Partner skills** — technology-specific (our domain packs)
+- **Enterprise skills** — your organization's knowledge (our mission-critical thinking model)
+
+The key insight: institutional knowledge accumulates. When one engineer writes a skill or improves a pack, every agent in the organization gets better — regardless of which AI tool that engineer uses. Day 30 is measurably better than day 1.
+
+We didn't wait for the industry to tell us this. sbp-skills has been encoding SBP's mission-critical expertise into portable, composable skills from the start. But it's good to know we're on the right track.
+
 ## What we believe
 
 **The senior engineer's judgment should be portable.** When a senior SBP engineer reviews code, they ask questions that generic tools don't: "What's the blast radius? Who gets paged? Can we roll this back in 15 minutes? What happens when this dependency is unavailable?" That judgment shouldn't live only in people's heads. It should be available to every engineer, in every project, in every AI interaction.


### PR DESCRIPTION
## Summary

- Rewrite README opening to lead with the industry-wide "Stop building agents, build Skills" paradigm shift, referencing the Anthropic talk at AI Engineer Code Summit
- Emphasize multi-agent portability — same skills work across Claude Code, GitHub Copilot, OpenCode, and any markdown-reading agent
- Add "The industry is catching up" section to WHY.md, mapping Anthropic's three skill categories (foundational, partner, enterprise) to our baseline, domain packs, and mission-critical thinking model

## Test plan

- [x] Verify README renders correctly on GitHub (quote block, bold, links)
- [x] Verify WHY.md section fits naturally between "The problem" and "What we believe"
- [x] Confirm YouTube link to the talk is valid