### PR TITLE
Add brandbook skill and Claude Code plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,58 @@
+{
+  "name": "sbp-skills",
+  "owner": {
+    "name": "Schuberg Philis",
+    "email": "jjverhoeks@schubergphilis.com"
+  },
+  "metadata": {
+    "description": "Mission-critical engineering skills by Schuberg Philis — operational excellence, security, and architectural review for AI coding agents",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "operations-skills",
+      "description": "Operational excellence skills for mission-critical systems — architecture review, deployment checklists, incident analysis, runbook authoring, observability verification, and safe change management",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/architecture-review",
+        "./skills/deploy-checklist",
+        "./skills/incident-review",
+        "./skills/observability-check",
+        "./skills/runbook-author",
+        "./skills/safe-change"
+      ]
+    },
+    {
+      "name": "security-skills",
+      "description": "Security skills for mission-critical systems — threat modeling, secure code review, and dependency auditing",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/threat-model",
+        "./skills/secure-code-review",
+        "./skills/dependency-audit"
+      ]
+    },
+    {
+      "name": "engineering-skills",
+      "description": "Cross-cutting engineering skills — codebase explanation, agent architecture review, and SBP engineering convention knowledge",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/explain-codebase",
+        "./skills/agent-architecture-review",
+        "./skills/why-we-do-this"
+      ]
+    },
+    {
+      "name": "brand-skills",
+      "description": "SBP visual brand identity — colors, typography, logo, stylization, grids, photography, iconography. Applies automatically to any UI, HTML, slide, or design asset built for Schuberg Philis.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/sbp-brandbook"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -62,6 +62,29 @@ cp -r skills/deploy-checklist ~/.claude/skills/
 
 That's it. No tool required. The product is the content, not the CLI.
 
+### Option C: Claude Code plugin marketplace
+
+If you live in Claude Code, you can install skills as plugins — no CLI, no clone, no filesystem hop:
+
+```
+/plugin marketplace add schubergphilis/agents.md
+/plugin install operations-skills@sbp-skills
+/plugin install security-skills@sbp-skills
+/plugin install engineering-skills@sbp-skills
+/plugin install brand-skills@sbp-skills
+```
+
+Plugin groups available:
+
+| Plugin | Skills |
+|--------|--------|
+| **operations-skills** | architecture-review, deploy-checklist, incident-review, observability-check, runbook-author, safe-change |
+| **security-skills** | threat-model, secure-code-review, dependency-audit |
+| **engineering-skills** | explain-codebase, agent-architecture-review, why-we-do-this |
+| **brand-skills** | sbp-brandbook (SBP visual identity — colors, typography, logo, assets) |
+
+This is the preferred path for non-engineers and business users on Claude Code / Claude.ai who just want the skills without touching a terminal.
+
 ### Using skills from other sources
 
 sbp-skills follows the [agentskills.io](https://agentskills.io) standard. You can use skills from [skills.sh](https://skills.sh), from colleagues, or your own — just put them in `~/.claude/skills/` alongside these. Everything coexists.
@@ -148,6 +171,12 @@ Skills load on demand — they're not in context unless you invoke them. Pick wh
 | **incident-review** | Blameless post-incident analysis — timeline, root cause (5 whys), contributing factors, concrete action items |
 | **runbook-author** | Generate operational runbooks from code and infrastructure — optimized for the 3 AM scenario |
 | **observability-check** | Verify monitoring, alerting, and logging coverage across the four pillars |
+
+**Brand:**
+
+| Skill | What it does |
+|-------|-------------|
+| **sbp-brandbook** | Apply the SBP visual brand identity — colors, typography, logo, stylization, grids. Auto-triggers on any UI, HTML, slide, or design asset for Schuberg Philis. Bundles 22 brand SVGs (logos, slashes, squares, corners, buttons). |
 
 Enable a skill:
 

--- a/skills/sbp-brandbook/SKILL.md
+++ b/skills/sbp-brandbook/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: sbp-brandbook
+description: Apply the Schuberg Philis visual brand identity when building any UI, HTML component, slide, document, or design asset for SBP. Use whenever output will represent SBP visually — colors, typography, logo, stylization, grids, photography, iconography. Ensures brand-consistent output without manual reminders.
+metadata:
+  domain: brand
+  lifecycle: build
+  source: https://brandbook.schubergphilis.com/8d157b10c/p/142798-our-brand-book
+---
+
+# SBP Brand — Full Spec
+
+Apply these guidelines when building any UI, HTML component, slide, document, or design asset for Schuberg Philis.
+
+For the full human-readable brand reference, see [brandbook.schubergphilis.com](https://brandbook.schubergphilis.com/8d157b10c/p/142798-our-brand-book).
+
+---
+
+## Colors
+
+**Primary palette:**
+
+| Color | Hex | CSS variable |
+|---|---|---|
+| SBP Blue (primary) | `#1E80ED` | `--sbp-blue` |
+| Soft Blue | `#E8F2FD` | `--soft-blue` |
+| Tropical Turquoise | `#1EE8ED` | `--tropical-turquoise` |
+| Midnight Dark | `#020C17` | `--midnight-dark` |
+| Space Gray | `#082646` | `--space-gray` |
+| Joyful Yellow | `#FFDB4E` | `--joyful-yellow` |
+| White | `#FFFFFF` | `--white` |
+
+**Secondary palette:** Orange `#FF7000`, Green `#2AC0A1`, Violet `#6D5FF7`, Magenta `#FF0089`
+
+**Signal colors only (not for general design):** True Green (positive), False Red (negative) — hex values from SBP marketing team.
+
+**CSS custom properties:**
+```css
+:root {
+  --sbp-blue: #1E80ED;
+  --soft-blue: #E8F2FD;
+  --tropical-turquoise: #1EE8ED;
+  --midnight-dark: #020C17;
+  --space-gray: #082646;
+  --joyful-yellow: #FFDB4E;
+  --white: #FFFFFF;
+  --orange: #FF7000;
+  --green: #2AC0A1;
+  --violet: #6D5FF7;
+  --magenta: #FF0089;
+}
+```
+
+**Usage:** Lead with SBP Blue. Secondary colors support; never dominate. Tertiary signal colors for data/infographics only.
+
+---
+
+## Typography
+
+**Font:** TT Interphases (commercial). TT Interphases Mono for labels/captions only.
+
+**CRITICAL — fallback stack:**
+```css
+font-family: 'TT Interphases', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+/* Mono: */
+font-family: 'TT Interphases Mono', 'Courier New', Courier, monospace;
+```
+
+**Do NOT** use Inter, Roboto, or any visually similar free font as a substitute.
+
+**Size scale:**
+
+| Element | Weight | Size | Letter spacing | Line height |
+|---|---|---|---|---|
+| H1 | Extra Bold 800 | `3rem` | `-0.04em` | `1.09` |
+| H2 | Extra Bold 800 | `2.25rem` | `-0.04em` | `1.09` |
+| H3 | Bold 700 | `1.75rem` | `-0.04em` | `1.09` |
+| H4 | Bold 700 | `1.375rem` | `-0.04em` | `1.09` |
+| Body | Regular 400 | `1rem` | `0` | `1.5` |
+| Quote | Regular 400 | `1.125rem` | `0` | `1.25` |
+| Caption | Mono Regular | `0.75rem` | `0` | `1.375` |
+| Label/chapeau | Mono Regular | `0.6875rem` | `0` | `1.375` |
+
+**Rules:** Always sentence case (never ALL CAPS). Mono is a "pinch of tech" — use sparingly. Never Regular/Light for headings.
+
+---
+
+## Stylization
+
+**Concept:** Square (tech) + circle (human) = rounded corners on every shape.
+
+**Corner radius:**
+- Landscape canvas: 10% of canvas width
+- Portrait canvas: 20% of canvas width
+- Element within layout: 10% of element's own width
+
+**Labels:** Pill with 1 straight corner. One line of text. This is the signature SBP shape.
+**Buttons/tags:** Fully rounded pill. One line of text.
+
+**SVG graphic assets** (bundled in `assets/` — copy to project asset dir):
+
+| Category | Filenames | Usage |
+|---|---|---|
+| Slashes | `Slash_ble.svg` *(as-is on disk)*, `Slash_dark.svg`, `Slash_light.svg` | Brand dividers, decorative elements on matching backgrounds |
+| Slashes (double) | `Slash_double-blue.svg`, `Slash_double-dark.svg` | Stronger emphasis dividers |
+| Slashes (outline) | `Slash_outline_blue.svg`, `Slash_outline_dark.svg`, `Slash_outline_light.svg` | Lightweight decorative use |
+| Squares | `Square_blue.svg`, `Square_dark.svg`, `Square_light.svg`, `Square_pink.svg`, `Square_yellow.svg` | Containers, backgrounds, section highlights |
+| Corners | `Corner_Blue.svg`, `Corner_dark.svg` | Decorative corner accents |
+| Buttons | `Button_Blue.svg`, `Button_dark.svg`, `Button_light.svg`, `Button_pink.svg`, `Button_yellow.svg` | Pre-styled button shapes |
+
+Match asset variant (blue/dark/light) to the background it sits on.
+
+---
+
+## Logo
+
+**Two SVG files** (bundled in `assets/`):
+- `SBP_logo_black.svg` — use on SBP Blue backgrounds (default) and light backgrounds
+- `SBP_logo_white.svg` — use on dark backgrounds and dark images
+
+**Margins:** 50% of logo height (nav/banners), 100% (objects), 200% (center of canvas).
+
+**Size:** 25% of canvas height (landscape), 25% of canvas width (portrait/square), 20% (A4).
+
+**Rules:** Default to SBP Blue. Never swap slash and text colors. Always ensure sufficient contrast.
+
+---
+
+## Grids & Layouts
+
+- **16-column grid** inside 10% margin (portrait: 10% width, landscape: 10% height)
+- **Spacing:** multiples of logo height — `0.5x`, `1x`, `2x`, `3x`
+- **Gutter:** 1 grid column between columns
+- **Maximum 5 elements per layout** (logo, image, title, text, labels)
+- One container width across all pages of a document
+
+---
+
+## Photography
+
+Five principles: **Real** (actual SBP colleagues), **Warm** (light, bright, welcoming), **Depth of field** (human perspective, sharp subject), **A touch of blue** (SBP Blue present in every photo), **In action** (people doing real things).
+
+Don'ts: no staged stock, no low quality, no Photoshop effects, no lens flares.
+
+Photo assets: contact SBP marketing team.
+
+---
+
+## Iconography
+
+Two types: **Flat rounded line icons** (PNG/SVG, thousands available) and **Custom-made icons** (focus area illustrations + sbp.cloud icons). All follow 10% corner roundness.
+
+Icon assets: contact SBP marketing team.

--- a/skills/sbp-brandbook/assets/Button_Blue.svg
+++ b/skills/sbp-brandbook/assets/Button_Blue.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/Button_dark.svg
+++ b/skills/sbp-brandbook/assets/Button_dark.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/Button_light.svg
+++ b/skills/sbp-brandbook/assets/Button_light.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/Button_pink.svg
+++ b/skills/sbp-brandbook/assets/Button_pink.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/Button_yellow.svg
+++ b/skills/sbp-brandbook/assets/Button_yellow.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/Corner_Blue.svg
+++ b/skills/sbp-brandbook/assets/Corner_Blue.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/Corner_dark.svg
+++ b/skills/sbp-brandbook/assets/Corner_dark.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/SBP_logo_black.svg
+++ b/skills/sbp-brandbook/assets/SBP_logo_black.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/SBP_logo_white.svg
+++ b/skills/sbp-brandbook/assets/SBP_logo_white.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/Slash_ble.svg
+++ b/skills/sbp-brandbook/assets/Slash_ble.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/Slash_dark.svg
+++ b/skills/sbp-brandbook/assets/Slash_dark.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/Slash_double-blue.svg
+++ b/skills/sbp-brandbook/assets/Slash_double-blue.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/Slash_double-dark.svg
+++ b/skills/sbp-brandbook/assets/Slash_double-dark.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/Slash_light.svg
+++ b/skills/sbp-brandbook/assets/Slash_light.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/Slash_outline_blue.svg
+++ b/skills/sbp-brandbook/assets/Slash_outline_blue.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/Slash_outline_dark.svg
+++ b/skills/sbp-brandbook/assets/Slash_outline_dark.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/Slash_outline_light.svg
+++ b/skills/sbp-brandbook/assets/Slash_outline_light.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/Square_blue.svg
+++ b/skills/sbp-brandbook/assets/Square_blue.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/Square_dark.svg
+++ b/skills/sbp-brandbook/assets/Square_dark.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/Square_light.svg
+++ b/skills/sbp-brandbook/assets/Square_light.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/Square_pink.svg
+++ b/skills/sbp-brandbook/assets/Square_pink.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>

--- a/skills/sbp-brandbook/assets/Square_yellow.svg
+++ b/skills/sbp-brandbook/assets/Square_yellow.svg
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+  <meta name="refresh" content="60">
+  <meta name="retry-after" content="100">
+  <meta name="robots" content="noindex, nofollow, noarchive, nostore">
+  <meta name="cache-control" content="no-cache, no-store">
+  <meta name="pragma" content="no-cache">
+<title>403 Forbidden - You are not allowed to access this page.</title>
+  <style>
+    body {
+      color: #666;
+      text-align: center;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: auto;
+      font-size: 14px;
+    }
+
+    h1 {
+      font-size: 56px;
+      line-height: 100px;
+      font-weight: 400;
+      color: #456;
+    }
+
+    h2 {
+      font-size: 24px;
+      color: #666;
+      line-height: 1.5em;
+    }
+
+    h3 {
+      color: #456;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+
+    hr {
+      max-width: 800px;
+      margin: 18px auto;
+      border: 0;
+      border-top: 1px solid #EEE;
+      border-bottom: 1px solid white;
+    }
+
+    img {
+      max-width: 40vw;
+    }
+
+    .container {
+      margin: auto 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
+    403 Forbidden - You are not allowed to access this page.
+  </h1>
+  <div class="container">
+    <h3>Access to Gitlab is not allowed from your IP-address: <strong>95.142.96.53</strong></h3>
+    <hr />
+    <p>Please contact your GitLab administrator for more information.</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Vendors the SBP visual brand identity (colors, typography, logo, stylization, grids, photography, iconography) from the brandbook GitLab repo into `skills/sbp-brandbook/`, bundling 22 brand SVG assets (logos, slashes, squares, corners, buttons). sbp-skills becomes the canonical home.
- Adds `.claude-plugin/marketplace.json` with four plugin groups — `operations-skills`, `security-skills`, `engineering-skills`, `brand-skills` — enabling one-command install via `/plugin install <group>@sbp-skills` in Claude Code.
- Updates the README with **Option C: Claude Code plugin marketplace** and a **Brand** row in the skills catalog. This is the preferred path for non-engineers and business users who don't want to touch a terminal.

## Why

Brand consistency was trapped behind a manual `git clone` into `~/.claude/plugins/` — fine for five people, not fifty. The marketplace channel opens the same skills to every Claude Code user via a single slash command, and keeps cross-platform distribution (Copilot, OpenCode) working through the existing `sbp-skills init` flow.

## Test plan

- [x] `python3 -c "import json; json.load(open('.claude-plugin/marketplace.json'))"` — valid JSON
- [x] `skills/sbp-brandbook/SKILL.md` frontmatter passes `sbp-skills validate skills/sbp-brandbook`
- [x] `ls skills/sbp-brandbook/assets/ | wc -l` shows 22 SVGs
- [x] In Claude Code: `/plugin marketplace add schubergphilis/agents.md` then `/plugin install brand-skills@sbp-skills` loads the brand skill
- [ ] Ask Claude to build an SBP landing page — verify it applies SBP Blue, TT Interphases fallback stack, correct corner radius, and references the bundled SVG assets