### PR TITLE
Convert five prompts into engineering skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -43,7 +43,11 @@
         "./skills/explain-codebase",
         "./skills/agent-architecture-review",
         "./skills/why-we-do-this",
-        "./skills/feature-development"
+        "./skills/feature-development",
+        "./skills/debug-investigation",
+        "./skills/refactor",
+        "./skills/test-planning",
+        "./skills/test-authoring"
       ]
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -42,7 +42,8 @@
       "skills": [
         "./skills/explain-codebase",
         "./skills/agent-architecture-review",
-        "./skills/why-we-do-this"
+        "./skills/why-we-do-this",
+        "./skills/feature-development"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -157,12 +157,16 @@ Skills load on demand — they're not in context unless you invoke them. Pick wh
 | **architecture-review** (default) | Review systems for single points of failure, blast radius, rollback paths, observability gaps, operational readiness |
 | **threat-model** | Structured threat modeling — assets, threat actors, attack surfaces, mitigations, prioritized actions |
 | **agent-architecture-review** | Review multi-agent system designs against a three-layer reference model (guardian/orchestration/worker) |
+| **test-planning** | Design comprehensive test coverage before implementation — behaviors, boundary cases, failure modes, right test type for each |
 
 **Building:**
 
 | Skill | What it does |
 |-------|-------------|
 | **feature-development** | Build a new feature using test-driven development — clarify requirements, plan test coverage, drive through red/green/refactor, integrate, and verify |
+| **debug-investigation** | Systematically investigate, reproduce, and fix software bugs — frame symptoms, reliably reproduce, isolate the root cause, write a regression test, then fix |
+| **refactor** | Improve code structure without changing observable behavior — establish a safety net, plan small reversible steps, execute iteratively, validate no regressions |
+| **test-authoring** | Write tests that prove functionality works and catch regressions — structure each test clearly, exercise real behavior, keep the suite fast and reliable |
 | **secure-code-review** | Security-focused review — auth, injection, secrets, dependencies, OWASP Top 10 |
 | **dependency-audit** | Analyze dependencies for bloat, supply-chain risk, and unused packages |
 | **explain-codebase** | Deep explanation of unfamiliar code — traces data flow, names patterns, explains design decisions |

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Skills load on demand — they're not in context unless you invoke them. Pick wh
 
 | Skill | What it does |
 |-------|-------------|
+| **feature-development** | Build a new feature using test-driven development — clarify requirements, plan test coverage, drive through red/green/refactor, integrate, and verify |
 | **secure-code-review** | Security-focused review — auth, injection, secrets, dependencies, OWASP Top 10 |
 | **dependency-audit** | Analyze dependencies for bloat, supply-chain risk, and unused packages |
 | **explain-codebase** | Deep explanation of unfamiliar code — traces data flow, names patterns, explains design decisions |

--- a/skills/debug-investigation/SKILL.md
+++ b/skills/debug-investigation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: debug-investigation
+description: Systematically investigate, reproduce, and fix software bugs — frame the symptoms, reliably reproduce, isolate the root cause, write a regression test, then fix. Use when chasing a bug, especially in mission-critical systems where "works on my machine" is not an acceptable resolution.
+metadata:
+  domain: cross-cutting
+  lifecycle: build
+---
+
+# Debug Investigation
+
+This skill walks you through debugging methodically. The temptation when chasing a bug is to jump to hypotheses and start patching. Resist. A symptom that looks like X is often caused by Y, and the patch for X will leave Y lurking until it surfaces at 3 AM.
+
+The goal: reproduce reliably, find the root cause, prove you found it, fix once.
+
+## Step 1: Frame the problem
+
+Before touching code, get the facts. Vague bug reports lead to vague fixes.
+
+Collect:
+
+- **Exact symptoms**: what was expected, what happened instead. "It is broken" is not a symptom.
+- **Error messages and stack traces**: the complete text, not a paraphrase.
+- **Logs**: from the affected system, around the time of the failure.
+- **Scope**: which users, which requests, which environments. One user or all? One region or global?
+- **Timing**: when did this start? What changed around that time — deploy, config change, traffic shift, external dependency?
+- **Business impact**: what is the cost of this bug right now? That shapes how much investigation rigour is warranted.
+
+If the report is fuzzy, go back to the reporter. Investigating a misstated bug burns time on the wrong problem.
+
+## Step 2: Reproduce reliably
+
+You cannot fix what you cannot reproduce. Chasing an intermittent bug without a repro is guessing.
+
+Work toward a minimal, deterministic reproduction:
+
+- Start with the steps the reporter gave. Verify they reproduce the bug.
+- Strip away everything not needed to trigger it. What is the smallest input, the shortest path, the cleanest state?
+- If it reproduces only in production: capture enough data (inputs, state, timing) that you can replay it in a test environment.
+- If it is timing-dependent: introduce controlled delays, run it in a loop, stress the relevant resource.
+- If it appears random: look for hidden state — cached values, database rows, feature flags, leader election, time of day.
+
+A stable repro is often 80% of the fix. Once you can trigger it on demand, you can iterate fast.
+
+## Step 3: Isolate the root cause
+
+With a repro in hand, narrow down. Do not guess — bisect.
+
+- **Bisect by version**: if it worked yesterday and not today, `git bisect` to find the commit that broke it.
+- **Bisect by input**: which part of the input triggers the bug? Remove parts one at a time until the bug disappears.
+- **Bisect by code path**: add logging, breakpoints, or print statements at decision points. Find where the actual behaviour diverges from the expected.
+- **Check assumptions**: the first thing to verify is something you are sure of. "Of course the config is loaded" — is it? Actually?
+
+Distinguish the *cause* from the *trigger*. The trigger is what makes it happen today. The cause is the underlying defect. A race condition triggered by traffic growth has "traffic growth" as the trigger and "missing lock" as the cause. Fix the cause.
+
+Beware the first hypothesis that fits. Ask: does this explanation account for every symptom, including the ones that do not fit my first theory? If not, keep digging.
+
+## Step 4: Write the regression test first
+
+Before writing the fix, write a test that reproduces the bug and fails because of it.
+
+- The test must fail on the current code.
+- The test must pass after the fix.
+- If the test is still green without the fix, the test does not actually exercise the bug.
+
+This test is how you know you fixed it. It is also how future changes avoid reintroducing the bug. A bug without a regression test will come back.
+
+## Step 5: Fix the root cause, minimally
+
+Apply the smallest change that addresses the root cause.
+
+- **Fix the cause, not the symptom**: patching the error message so it no longer appears is not a fix.
+- **Avoid defensive coding everywhere**: add input validation at boundaries, not in every function. Scattering `if x is None:` checks obscures the real problem.
+- **Keep the diff focused**: this is a bug fix. Not a refactor, not a cleanup. Separate concerns into separate changes.
+- **Verify the fix in isolation**: run the new test, confirm it passes. Then run the full suite to catch regressions.
+
+If the fix requires a significant change — new abstraction, architectural shift, migration — stop. The bug fix is one thing; the larger change is another. Ship the minimal fix, then plan the larger change separately.
+
+## Step 6: Validate the full picture
+
+Before marking this resolved:
+
+- **Full test suite**: the new test passes, nothing else broke.
+- **Realistic scenarios**: run the feature in a production-like environment with production-like data.
+- **Adjacent bugs**: the investigation may have surfaced related issues. Note them — do not necessarily fix them now, but do not lose them either.
+- **Observability**: if this bug went unnoticed, could better monitoring have caught it sooner? Add the signal.
+
+## Step 7: Capture what you learned
+
+Write it down. Future you, or future teammates, will face similar bugs.
+
+- **Root cause**: one clear sentence. Not "the code was wrong" — the *specific* wrong thing.
+- **How it was missed**: what allowed this to reach production? Test gap? Review miss? Monitoring gap? Unclear assumption?
+- **How you would catch it sooner**: what signal, test, or review practice would flag this earlier next time?
+
+For production-impacting bugs, this belongs in a post-incident review. For smaller bugs, a note in the PR description is enough.
+
+## Common anti-patterns to avoid
+
+- **"It works now, I don't know why"**: if you cannot explain why the fix works, you have not finished investigating. You have a different bug waiting.
+- **Patching the symptom**: swallowing the exception, raising the timeout, retrying blindly. Each hides the cause for next time.
+- **Fixing without a repro**: "I think this might be it" and shipping. You do not know you fixed anything.
+- **Fixing without a test**: the bug will return. You just do not know when.
+- **Scope creep**: "while I'm fixing this, let me also..." — stop. Fix the bug, open a separate issue for the rest.
+- **Skipping the write-up**: the second team member to hit this bug wastes hours you could have saved them in five minutes.
+
+## Closing notes
+
+Good debugging is slow on purpose. Each step narrows the possibilities. Skipping steps feels faster but usually costs more — because a bug that is not fully understood is a bug that is not really fixed.
+
+The reward for rigour is that the bug stays fixed.

--- a/skills/feature-development/SKILL.md
+++ b/skills/feature-development/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: feature-development
+description: Build a new feature using test-driven development — clarify requirements, plan test coverage, drive implementation through red/green/refactor, integrate, and verify. Use when starting any feature that will reach production, especially in mission-critical systems where untested code is a liability.
+metadata:
+  domain: cross-cutting
+  lifecycle: build
+---
+
+# Feature Development
+
+This skill walks you through building a new feature using test-driven development. The goal is not ceremony — it is to reach production with a feature that works, has a regression safety net, and does not break what already works.
+
+TDD is particularly valuable in mission-critical systems: the test you write before the code is the test that will wake someone up if this feature regresses at 3 AM.
+
+## Step 1: Understand what you are building
+
+Before writing any code or tests, answer these questions in plain language:
+
+- **What does the user or caller need to do that they cannot do today?** State this as a capability, not an implementation.
+- **What is the acceptance criteria?** How will you know this feature works? Be specific enough that someone else could verify it.
+- **What is the blast radius?** Which existing systems does this feature touch? What could break?
+- **What is the non-goal?** What are you explicitly *not* doing in this iteration?
+
+If any of these are unclear, stop and ask. Writing code against fuzzy requirements is the most expensive form of rework.
+
+## Step 2: Plan the test coverage
+
+Design the tests before writing the code. Think about what could go wrong, not just the happy path.
+
+For each piece of the feature, identify:
+
+- **Golden path**: the common, expected case.
+- **Boundary cases**: empty input, max length, zero, one, many, negative.
+- **Failure modes**: what happens when the database is down, the external API times out, input is malformed, the user is unauthorized?
+- **Integration seams**: where does this feature meet existing code? What are the assumptions at that boundary?
+
+Write the test plan down. It does not need to be formal — a bulleted list is enough. The point is to decide coverage *before* implementation pressure creates shortcuts.
+
+## Step 3: Consider refactoring first
+
+If the existing code makes the feature harder to add, refactor first — with its own tests — before starting the feature.
+
+Signs refactoring should come first:
+- You need to change an existing function's signature.
+- You cannot test the feature without also changing unrelated behavior.
+- You find yourself wanting to duplicate logic to avoid touching the original.
+
+Refactoring before feature work keeps the feature diff clean and the review focused.
+
+## Step 4: Drive implementation through red/green/refactor
+
+Execute one loop per behavior, not per function:
+
+- **Red**: write a failing test that describes the desired behavior. Run it. Confirm it fails for the *right reason* — not a syntax error, but because the behavior does not exist yet.
+- **Green**: write the minimum code needed to make the test pass. Resist adding anything the test does not demand. "Minimum" includes hardcoded values if that is what the current test requires — subsequent tests will force generalization.
+- **Refactor**: with tests green, improve the code. Remove duplication, clarify names, extract helpers. Run tests after each change.
+
+Repeat for each behavior: golden path first, then boundary cases, then failure modes.
+
+Do not skip the refactor step. Skipping it is how test-driven code ends up as messy as untested code — just more of it.
+
+## Step 5: Add error handling and edge cases deliberately
+
+Do not sprinkle defensive code everywhere. Decide explicitly where each class of error is handled.
+
+- **Input validation**: at the boundary where input enters your system (API handler, CLI parser, message consumer). Not in every internal function.
+- **External calls**: wrap with timeouts, retries where appropriate, and clear failure modes. Do not silently swallow.
+- **Unexpected state**: fail fast and loud. An assertion that crashes is better than a silent wrong answer in production.
+
+Every error path should have a test. If a failure mode is worth handling, it is worth proving with a test that it *is* handled.
+
+## Step 6: Integration verification
+
+With unit tests green, verify the feature in realistic context:
+
+- **Run the full test suite**: not just the new tests. Regressions often live in code you did not think you touched.
+- **Run the feature end-to-end**: against a real database, real network, real dependencies (or faithful stubs). Unit tests lie about integration.
+- **Exercise adjacent flows**: if this feature changes shared code, use the adjacent features that touch it. Do not wait for the customer to discover the regression.
+- **Check observability**: does the feature emit the metrics, logs, and traces you would need at 3 AM to diagnose a problem? If not, add them now. You will not add them later.
+
+## Step 7: Prepare for code review
+
+Before requesting review:
+
+- **Self-review the diff**: read it as if you were seeing it for the first time. Remove commented-out code, debug logging, and TODO stubs.
+- **Confirm the tests actually test**: a test that passes without the implementation is not a test. Temporarily break the implementation and confirm tests fail.
+- **Write the PR description**: what changed, why, and what to focus review on. If you cannot explain the *why* in two sentences, the feature may be over-scoped.
+- **Check the performance**: if this feature sits in a hot path, have you measured? Estimates are not measurements.
+
+## Step 8: Documentation and hand-off
+
+Update what must be updated, skip what is noise:
+
+- **User-facing docs**: if this changes behavior users observe.
+- **Runbook**: if this introduces a failure mode someone might be paged for.
+- **API reference**: if this adds or changes a public interface.
+- **Changelog**: if your project has one.
+
+Skip: explaining the code in prose. The code, its name, and its tests are the documentation for the implementation.
+
+## Common anti-patterns to avoid
+
+- **"I'll write tests after"**: the tests written after are different tests. They test what the code does, not what the feature should do. Write first.
+- **One big test that covers everything**: hard to read, hard to diagnose when it fails. Small, focused tests tell you exactly what broke.
+- **Mocking the thing you are actually testing**: a mock returning `True` does not prove correctness. Mock at the boundary, not inside the unit under test.
+- **Feature-creep during implementation**: "while I'm in here, I'll also..." — that is a separate PR. Finish the feature first.
+- **Skipping the refactor step**: "it works, ship it" — the second feature on this code will be slower for it.
+
+## Closing notes
+
+TDD is not about tests. It is about a tight feedback loop that catches your mistakes while they are cheap. The tests are a byproduct. The feedback is the product.
+
+A feature without tests is a feature that has never been proven to work — only observed to work once. In mission-critical systems, the difference matters.

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: refactor
+description: Improve code structure, readability, or maintainability without changing observable behavior — establish a safety net, plan small reversible steps, execute iteratively, and validate no regressions. Use before a feature needs existing code to change shape, or when code has drifted into a state that makes further work expensive.
+metadata:
+  domain: cross-cutting
+  lifecycle: build
+---
+
+# Refactor
+
+This skill walks you through refactoring safely. A refactor is a contract with yourself: observable behavior does not change. Inputs, outputs, side effects, error cases, and performance bounds stay the same; the shape of the code underneath is what moves.
+
+Violating that contract — even accidentally — turns a refactor into a bug delivery vehicle. This walkthrough keeps the contract intact.
+
+## Step 1: Establish why
+
+Refactoring without a clear objective drifts into "just tidying up." That kind of diff is hard to review, hard to justify, and often introduces risk with no upside.
+
+Name the specific goal:
+
+- **Unblock a feature**: existing code shape makes an upcoming feature hard to add cleanly.
+- **Reduce coupling**: two things that change for different reasons are currently tangled together.
+- **Improve testability**: the code has hidden dependencies or side effects that prevent testing.
+- **Reduce duplication**: the same logic appears in three places and they have started to drift.
+- **Clarify intent**: future readers (including future you) will misread this code.
+- **Remove dead weight**: unreachable code, unused exports, obsolete compatibility shims.
+
+If you cannot state the objective in one sentence, pause. Refactoring without a target is how weekends disappear.
+
+If you catch yourself wanting to change behavior during the refactor, stop. Scope that out as a separate change with its own tests.
+
+## Step 2: Establish the safety net
+
+You cannot refactor safely without tests. Period.
+
+Before touching code:
+
+- **Run the full test suite** and confirm it passes on the current code. The baseline is green.
+- **Assess coverage around the target**: are the paths you are about to reshape actually tested? Do the tests exercise the real behavior, or just the types?
+- **If coverage is inadequate**: write characterization tests first. These are not tests of desired behavior — they are tests that lock in *current* behavior, whatever that is, so you notice if you change it.
+- **Capture external contracts**: public APIs, data formats, error shapes, log lines consumers might depend on, performance budgets. These are the things that must not change.
+
+Characterization tests can feel like busy-work. They are the only thing standing between your refactor and a silent regression. Do not skip.
+
+## Step 3: Plan small, reversible steps
+
+A refactor executed in one huge diff is hard to review and hard to back out of. Plan a sequence of small, safe edits that each keep tests green.
+
+Typical safe edits, roughly in order of risk:
+
+- Rename symbols for clarity.
+- Extract a method or function from a long block.
+- Inline a method that adds no value.
+- Move a method or class to a better location.
+- Introduce a parameter object or struct to group related arguments.
+- Replace a temporary variable with a direct query.
+- Replace magic values with named constants.
+- Extract an interface or port to decouple from an implementation.
+- Introduce an adapter or facade to isolate a volatile dependency.
+- Split a class or module along a real seam.
+
+For each step, ask: if this step went wrong, how hard is it to undo? Small, reversible steps mean you can move fast without fear.
+
+Avoid large rewrites. If the target is "replace this entire subsystem," that is not a refactor — that is a rewrite, with different risks and a different plan.
+
+## Step 4: Execute iteratively
+
+Loop through the planned steps. After each one:
+
+- Run the tests. Must stay green.
+- If tests fail, revert immediately and investigate. Do not try to fix forward through a failing refactor.
+- Commit atomically with a descriptive message. Small commits make rollback and review easy.
+- Check formatting, linting, and type checks still pass.
+
+Do not batch multiple steps into one commit because they "feel related." Related steps that fail together are harder to diagnose than independent steps that either both passed or one failed.
+
+If a step turns out larger than planned, stop and split it. A step that takes more than one commit to get right was not actually one step.
+
+## Step 5: Preserve what must be preserved
+
+Throughout the refactor, verify the contract:
+
+- **Public APIs**: routes, function signatures, response schemas, thrown error types — unchanged.
+- **Side effects**: log lines, metric names, event emissions, database writes — unchanged in kind and shape.
+- **Performance**: the hot path should not get meaningfully slower. Measure if you are unsure.
+- **Concurrency behavior**: if the original handled concurrent access a certain way, the new code must too. Race conditions introduced during refactoring are particularly nasty because no one is looking for them.
+- **Error paths**: if the old code threw X on condition Y, the new code must too. Consumers may depend on it.
+
+When in doubt, write the behavior down as a test before you change the code.
+
+## Step 6: Validate at integration
+
+With unit tests green, check the whole system:
+
+- **Full suite**: not just your tests. Other teams' tests may exercise seams you moved.
+- **Realistic runs**: exercise the refactored code through the actual paths users and callers take, not just through tests.
+- **Performance**: if the refactor touched a hot path, measure before and after. Budget variance is defined by the system's requirements, not by your intuition.
+- **Observability**: logs, metrics, traces should still carry the same signal. A refactor that silences a useful log line is a regression in operability.
+
+## Step 7: Document what changed structurally
+
+If the refactor moved module boundaries, introduced new abstractions, or reshaped the architecture:
+
+- Update any internal documentation or architecture notes that describe the old shape.
+- Add a short note to the PR description explaining the new structure and why.
+- If the project has ADRs (architecture decision records), consider whether this warrants one.
+
+Skip: commenting the code to explain the shape. The code should read as its own explanation. If it does not, the refactor is not done.
+
+## Common anti-patterns to avoid
+
+- **"Refactor" that changes behavior**: if you changed what the code does, it is not a refactor — it is a feature or a bug fix in disguise. Split it.
+- **No tests, refactoring anyway**: you are not refactoring, you are rewriting and hoping. Add characterization tests first.
+- **One giant diff**: impossible to review, impossible to roll back. Small commits, each green.
+- **Pursuing perfect architecture**: refactors have diminishing returns. Stop when the original objective is met, not when the code is aesthetically pleasing.
+- **Refactoring under deadline pressure**: the temptation to skip the safety net is highest when you should least skip it. If you have no time for tests, you have no time for a refactor.
+- **Letting the refactor grow**: "while I'm in here..." — note it down, move on. Separate change, separate PR.
+
+## Closing notes
+
+A good refactor is invisible from the outside and obvious on the inside. Behavior unchanged, code clearer.
+
+The best refactor is one you can ship in small pieces over time, with the system green at every step. That way, if you are interrupted — and you will be — the code is never in a half-transformed state.

--- a/skills/test-authoring/SKILL.md
+++ b/skills/test-authoring/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: test-authoring
+description: Write tests that prove functionality works and catch regressions — structure each test clearly, exercise real behavior, cover happy paths and failure modes, and keep the suite fast and reliable. Use when writing new tests, adding coverage to existing code, or fixing flaky or low-value tests.
+metadata:
+  domain: cross-cutting
+  lifecycle: build
+---
+
+# Test Authoring
+
+This skill is about writing tests that earn their keep. A test that passes when the code is broken is worse than no test: it creates a false sense of safety and trains the team to trust the wrong signal.
+
+The goal: tests that read like a specification, fail when they should, run fast, and stay reliable.
+
+## Step 1: Know what each test is for
+
+Before writing a test, state in one sentence what it proves. If you cannot, the test is unfocused.
+
+Examples of a clear purpose:
+
+- "Valid credentials produce a session token."
+- "An expired token is rejected with 401."
+- "Concurrent updates to the same record do not lose data."
+- "A duplicate email returns the existing user rather than creating a new one."
+
+Examples of an unclear purpose:
+
+- "Test the login function." — tests *what* about it?
+- "Test happy path." — which happy path, and what does success mean?
+- "End-to-end test of the feature." — which behavior of the feature?
+
+If you have done test planning first, you already have this list. If not, pause and write it.
+
+## Step 2: Structure each test for readability
+
+A reader should understand a test in five seconds. That means a clear, consistent structure.
+
+**Arrange, Act, Assert** (or Given, When, Then):
+
+```
+def test_expired_token_is_rejected():
+    # Arrange
+    token = issue_token(expires_in=timedelta(seconds=-1))
+    
+    # When
+    result = authenticate(token)
+    
+    # Then
+    assert result.status == "rejected"
+    assert result.reason == "token_expired"
+```
+
+The three sections should be visually distinct. Setup noise, hidden mutations, and assertions scattered through the body are what make tests hard to debug years later.
+
+**Name tests after the behavior**, not the function under test:
+
+- `test_expired_token_is_rejected` (good) vs. `test_authenticate_1` (useless).
+- `test_duplicate_email_returns_existing_user` (good) vs. `test_create_user_edge_case` (useless).
+
+When a test fails, the name is the first diagnostic signal. A good name tells you what broke without reading the assertion.
+
+**Keep each test focused on one behavior**. If a test has multiple asserts and they cover different scenarios, split it. One test per behavior makes failures specific.
+
+## Step 3: Exercise real behavior, not implementation
+
+A test should prove the feature works, not that the code is shaped a certain way.
+
+**Assert on outcomes, not calls**:
+
+- Good: `assert order.total == Decimal("42.00")`
+- Bad: `assert calculator.calculate.called_once_with(...)`
+
+Outcome assertions survive refactoring; call assertions break the moment you restructure internals, even when behavior is unchanged.
+
+**Mock at the boundary, not inside the unit under test**:
+
+- Mock external services (databases, APIs, message queues) at their adapter layer.
+- Do not mock the thing you are testing. A function that has its internal calls mocked out is being "tested" against an imaginary version of itself.
+
+**Prefer real dependencies when they are cheap**:
+
+- A real in-memory SQLite, a real test double of the API, a real in-process queue — each gives more signal than a mock and costs little.
+- Reach for mocks when the dependency is genuinely slow, expensive, or non-deterministic, and even then only at the boundary.
+
+**Verify the test actually tests**: temporarily break the implementation (return a wrong value, skip a step) and confirm the test fails. A test that stays green when the code is broken is not a test.
+
+## Step 4: Cover the cases deliberately
+
+Use the test plan to guide coverage. If you do not have a plan, walk through these categories for each behavior:
+
+**Golden path**: the common, expected case. Must be covered.
+
+**Boundary cases**:
+
+- Empty input, minimum, maximum, off-by-one.
+- Unicode, whitespace, special characters.
+- Repeated calls, idempotency.
+
+**Failure modes**:
+
+- External dependency fails (timeout, 500, network error).
+- Invalid input (malformed, missing fields, wrong type).
+- Unauthorized access.
+- Resource exhaustion.
+
+**State-dependent cases**:
+
+- First call vs. repeated calls.
+- Empty state vs. populated state.
+- Feature flags on vs. off.
+
+Do not test every permutation of every input. Pick representatives: one boundary per boundary class, one failure mode per dependency, one state variant per meaningful state.
+
+When you skip a case deliberately, note it — in a comment on the test file or the PR description. "No test for concurrency: serial access enforced at call site" is a better signal than silence.
+
+## Step 5: Manage test data carefully
+
+Tests with opaque data are tests that lie. A fixture called `test_user_1` tells the reader nothing. Name data after what it represents.
+
+- **Name fixtures by role**: `customer_with_overdue_invoice`, `expired_session`, `admin_user`.
+- **Minimal realistic data**: include only the fields the test actually cares about. Extra data is noise that obscures intent.
+- **Factories over shared fixtures**: let each test build its own data. Shared fixtures create invisible coupling between tests.
+- **Avoid `sleep()`**: a test that sleeps is a test that is either flaky, slow, or both. Use deterministic control of time — inject a clock, advance it in the test.
+- **No dependence on real network, real time, or real randomness**: inject or stub all three. A test that passes today and fails tomorrow because DNS changed is not a test.
+
+## Step 6: Keep the suite fast and isolated
+
+A slow suite is a suite developers stop running. A flaky suite is a suite developers stop trusting.
+
+**Speed**:
+
+- Individual unit tests should run in well under a second.
+- Integration tests may take a few seconds; if they take longer, look for hidden setup cost (full database migration per test? regenerating fixtures from scratch?).
+- End-to-end tests can be slow but should be few in number.
+
+**Isolation**:
+
+- Each test must be runnable alone, in any order, repeatedly. No hidden ordering dependencies.
+- No shared mutable state across tests. Either create fresh state per test or reset explicitly in teardown.
+- Parallel execution should be safe. If it is not, find and fix the shared state — do not force serial execution.
+
+**Reliability**:
+
+- A test that fails "sometimes" is already broken. Investigate immediately — do not accept "rerun and hope."
+- Common flakiness sources: real time, real network, real filesystem, concurrency without synchronization, shared state.
+
+## Step 7: Make tests useful when they fail
+
+The test's job is to tell you something useful when it fails. Design for that.
+
+- **Clear assertions**: use the testing framework's native assertion helpers. `assert.equal(actual, expected)` gives a better failure message than `assert actual == expected`.
+- **One logical assertion per test**: so the failure line is precise.
+- **Meaningful variable names in the test body**: the stack trace and failure message should read as prose, not as `x`, `y`, `result`.
+- **Avoid deep call chains in the test itself**: a test that fails five helpers deep makes debugging harder. Keep test logic flat.
+
+## Step 8: Review your tests like code
+
+Tests are code. They rot, they accumulate, they need review.
+
+Before shipping:
+
+- **Are any tests doing the same thing?** Deduplicate.
+- **Are any tests actually testing nothing?** A test that passes unconditionally is technical debt.
+- **Can any tests be moved to a lower level?** An integration test covering logic that could be a unit test is slow and precise-less.
+- **Do the test names still describe the behavior?** Names drift after refactors. Keep them honest.
+
+When the feature ships, the tests become part of the asset and part of the liability. Treat them accordingly.
+
+## Common anti-patterns to avoid
+
+- **Asserting on internal calls**: brittle, breaks on refactor, proves nothing about behavior.
+- **Mocking the unit under test**: the test tests the mock, not the code.
+- **One big test covering the whole feature**: when it fails, you have no idea what broke.
+- **`time.sleep()` as a synchronization mechanism**: always flaky, always slow.
+- **Tests that are sometimes green, sometimes red**: a bug you have trained the team to ignore.
+- **Copy-paste tests**: the bug you copy into the test is the bug you will not catch.
+- **No negative tests**: "it works when everything is right" does not prove anything about resilience.
+- **Testing what you just implemented, not what the feature requires**: the test validates the code, not the behavior.
+
+## Closing notes
+
+Tests are the specification of the system, written in a form a computer can check. A good test suite is worth more than the code it tests: the code can be rewritten, but the behavioral contract the tests encode is what the users and callers actually depend on.
+
+Slow, flaky, or untrustworthy tests are worse than no tests. They train the team to ignore failure signals — and when a real regression appears, it passes unnoticed through a gate that people stopped watching.

--- a/skills/test-planning/SKILL.md
+++ b/skills/test-planning/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: test-planning
+description: Design comprehensive test coverage for a feature or change before implementation — identify behaviors, boundary cases, failure modes, and integration seams, then pick the right test type for each. Use before writing code, or before adding tests to untested code, especially in mission-critical systems where coverage gaps become incidents.
+metadata:
+  domain: cross-cutting
+  lifecycle: plan
+---
+
+# Test Planning
+
+This skill helps you design test coverage before you write tests. Starting implementation or writing tests without a plan leads to two failure modes: coverage of the happy path only (because that is the case you built), or coverage of everything you can think of at the time (bloated, slow, duplicative).
+
+The goal: decide *what* to test and *how* to test each thing, before the pressure of implementation narrows your thinking.
+
+## Step 1: Name the behaviors
+
+Start from the outside. What does this feature need to do, from the perspective of its caller or user?
+
+List behaviors in plain language, not implementation terms:
+
+- "When a user submits a valid form, they see a confirmation page."
+- "When the payment API times out, the order is retained and the user sees a retry option."
+- "When a duplicate email is submitted, the existing account is returned, not a new one."
+
+Each behavior is a test you will eventually write. The list is the skeleton of your test suite.
+
+If you cannot list behaviors without describing internal implementation ("calls the validator, then the persister"), the requirements are not clear yet. Go back to requirements before planning tests.
+
+## Step 2: Enumerate the cases
+
+For each behavior, think about the shapes of input and state that could hit it.
+
+**Golden path**: the common, expected case. This is the case the feature was built for. Always test it.
+
+**Boundary cases**:
+
+- Empty input: empty string, empty list, null.
+- Minimum and maximum values: one, many, max length, zero.
+- Edge of the valid range: just inside, just outside.
+- Unicode, whitespace, special characters in strings.
+- Concurrent or interleaved operations, if concurrency matters.
+
+**Failure modes**:
+
+- External dependencies fail: database down, API times out, network error.
+- Invalid input: malformed, missing required fields, wrong type.
+- Unauthorized access: wrong credentials, insufficient permissions, expired session.
+- Resource exhaustion: disk full, memory limit, rate limit hit.
+- Race conditions: two writers, stale reads, lost updates.
+
+**State-dependent cases**:
+
+- First time vs. repeated calls.
+- Cold cache vs. warm cache.
+- Fresh database vs. populated database.
+- Feature flag on vs. off.
+
+Not every category applies to every feature. Go through the list deliberately and mark which ones matter for this feature. A feature with no external dependencies does not need "API timeout" tests; a feature with five external dependencies has at least five.
+
+## Step 3: Pick the right test type for each case
+
+Not every case needs the same kind of test. Using the wrong type wastes runtime, hides bugs, or both.
+
+**Unit test**: a single function or small piece of logic, tested in isolation.
+
+- Best for: pure functions, complex business logic, calculations, parsers, state machines.
+- Cheap to write, fast to run, gives precise failure signals.
+- Weakness: lies about integration. A unit test with a mocked collaborator says nothing about whether the real collaborator works.
+
+**Integration test**: two or more real components talking to each other.
+
+- Best for: verifying that your code and the thing it depends on actually agree — your ORM and the database, your HTTP client and the API, your serializer and the consumer.
+- Catches bugs that unit tests cannot: schema mismatches, protocol disagreements, misconfigured clients.
+- Slower than unit tests, but much more trustworthy for boundary behavior.
+
+**End-to-end test**: full system from the outside, exercising the real runtime paths.
+
+- Best for: critical user journeys, regressions that cross component boundaries, "does the deploy actually work" smoke tests.
+- Slowest, most brittle, most expensive to maintain.
+- Use sparingly. One or two per critical journey is usually enough.
+
+**Contract test**: verifies your side of an agreement with another system.
+
+- Best for: team boundaries, versioned APIs, event schemas.
+- Catches: breaking changes before they reach the consumer.
+
+Rule of thumb: most coverage at the unit level, real boundaries covered by integration tests, critical journeys covered end-to-end. Invert the pyramid and your test suite becomes slow and flaky.
+
+## Step 4: Plan the data and state
+
+For each test, think about what setup it needs and what state it leaves behind.
+
+- **Test data**: specific inputs, realistic but minimal. Avoid lorem ipsum-style filler data that obscures intent — name the fixture after what it represents ("customer_with_overdue_invoices", not "test_customer_1").
+- **Fixtures vs. factories**: fixtures are fast but brittle; factories are flexible but slower. Choose per test category.
+- **Isolation**: each test should be runnable alone, in any order, repeatedly. Shared state between tests is a source of flakiness and slow debugging.
+- **Teardown**: what state does this test create in the database, the file system, the external service? It must be cleaned up or isolated so subsequent tests do not see it.
+
+If the feature touches external state (databases, message queues, files), decide now whether each test uses the real thing (integration) or a faithful stub (unit). Write it down so you are not making this choice 30 tests deep.
+
+## Step 5: Decide the non-functional targets
+
+Performance and reliability are testable too. Decide up front which ones matter for this feature.
+
+- **Speed**: individual tests should run in under a second. The full suite should stay fast enough that developers run it before every push. If a test is slow, know why.
+- **Reliability**: zero flakiness target. A test that fails once in twenty runs is worse than no test — it trains the team to ignore failures.
+- **Determinism**: no dependence on real time, real network, or real random values. Seed or inject them.
+
+If this feature has specific performance or throughput requirements, add tests for those too. A "it must handle 1000 requests/second" requirement needs a test, not a comment.
+
+## Step 6: Write the plan down
+
+Keep it short. A bulleted list is usually enough. The plan is for yourself and your reviewers, not for permanent documentation.
+
+```
+## Test plan: user profile update
+
+Unit tests
+- Valid update returns the updated profile
+- Missing required fields raise ValidationError
+- Fields beyond max length raise ValidationError
+- Unicode in name and bio round-trips correctly
+
+Integration tests
+- Update writes through to the database
+- Concurrent updates on the same profile: last write wins, no data loss
+- Update with stale version token is rejected
+
+End-to-end
+- Happy path: user logs in, edits profile, sees updated profile
+
+Not covered (and why)
+- Performance under load: no specific requirement; defer to load test suite
+- Profile image upload: separate feature, separate plan
+```
+
+The "not covered, and why" section is as important as the covered list. It makes deliberate the decision to skip something, and gives future readers a way to evaluate whether the scope was right.
+
+## Step 7: Review before you build
+
+A good test plan catches problems early. Before starting implementation:
+
+- **Read the plan as if you were reviewing it**: do the tests actually prove the behavior works, or just that the code compiles?
+- **Check for missing failure modes**: walk through the list of dependencies and ask, "if this fails, what do I expect?" If there is no test for it, either add one or explicitly call out that you are not testing it.
+- **Check for over-testing**: are three unit tests actually testing three different things, or variations of the same case? Redundant tests slow the suite without catching more bugs.
+- **Challenge the test types**: is this unit test carrying more weight than a unit test should? Does this e2e test really need to be e2e?
+
+The reviewer can be a colleague, a rubber duck, or yourself the next day. Fresh eyes on the plan save days of rework on the implementation.
+
+## Common anti-patterns to avoid
+
+- **Plan-free testing**: writing tests as you go, based on whatever you just implemented. You end up testing what you built, not what the feature should do.
+- **Testing implementation, not behavior**: "calls the validator" is not a useful assertion. "Rejects invalid input" is.
+- **Exhaustive coverage of the happy path, nothing else**: the most common real failure mode. Failures live in the unhappy paths.
+- **Mocking everything**: mocks that return whatever you tell them always pass. They prove nothing.
+- **Ignoring flakiness**: "it's flaky but it usually passes" is a bug you are choosing not to fix. It will bite later.
+- **Over-reliance on e2e**: slow, brittle, hard to diagnose. Reach for unit and integration first.
+
+## Closing notes
+
+A test plan is cheap to write and expensive to skip. Fifteen minutes of planning saves hours of implementation thrashing and catches scope gaps before they become production gaps.
+
+The plan is also the first useful artifact for code review: "here is what I intend to build and verify." Reviewers can push back on the plan before a single line of code is written.


### PR DESCRIPTION
## Summary

Converts the five highest-value prompts from `prompts/` on `main` into proper agentskills.io skills, following the sbp-skills style (imperative voice, mission-critical framing, step-by-step, anti-patterns section, closing note).

New skills added to `engineering-skills` plugin group:

| Skill | Lifecycle | From prompt |
|-------|-----------|-------------|
| **feature-development** | build | `feature_dev.md` |
| **debug-investigation** | build | `debug_bug.md` |
| **refactor** | build | `refactor.md` |
| **test-planning** | plan | `test_plan.md` |
| **test-authoring** | build | `test_author.md` + `write_tests.md` (merged) |

Together these cover the full TDD + debugging + refactor engineering workflow.

## Why

The `prompts/` directory on `main` predates the Skills paradigm. The legacy pattern required users to manually chain workflows with hashtag composition (`Use #context_intake then #test_plan then #feature_dev`). Skills auto-activate via their description field — no chaining needed.

Converting these into skills:
- Makes them discoverable across all agents (Claude Code, Copilot, OpenCode)
- Installable via the marketplace for Claude Code / Claude.ai users
- Reframes the content in mission-critical SBP voice
- Deduplicates overlapping prompts (merged `test_author` + `write_tests`)

Once these land, the legacy `prompts/` directory on `main` can be retired.

## Deliberately skipped

The following prompts were not converted — they overlap with existing skills or have marginal value:

- Overlap with existing: `code_review` (≈ secure-code-review), `impl_change` (≈ safe-change), `incident_resp` (≈ incident-review), `code_orient` (≈ explain-codebase)
- Sub-steps, not standalone skills: `run_all_tests`, `reproduce_bug`, `isolate_cause`
- Obsolete orchestration helpers: `context_intake`, `route_task`
- Meta/docs: `prompt_network`, `contributing`, `definition_of_done`
- Marginal value: `doc_update`, `env_setup`, `product_strategy`, `support_triage`, `quick_fix`

## Test plan

- [ ] `python3 -c \"import json; json.load(open('.claude-plugin/marketplace.json'))\"` — valid JSON
- [ ] All 5 SKILL.md files parse with required frontmatter (`name`, `description`, `metadata.domain`, `metadata.lifecycle`)
- [ ] In Claude Code: `/plugin install engineering-skills@sbp-skills` includes all 5 new skills
- [ ] Each skill triggers on its description: ask Claude to "build a new feature", "debug a bug", "refactor this module", "plan tests for X", "write tests for Y" — confirm the matching skill activates