### PR TITLE
Carve out brandbook as proprietary — not covered by Apache 2.0

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,24 @@
+sbp-skills — License Notice
+===========================
+
+This repository is licensed under the Apache License, Version 2.0 (see
+LICENSE). The following exception applies:
+
+Proprietary content — excluded from the Apache 2.0 License
+----------------------------------------------------------
+
+`skills/sbp-brandbook/` — The Schuberg Philis brand skill, including
+the SKILL.md instructions and all SVG assets under `assets/`, is the
+proprietary intellectual property of Schuberg Philis. It is governed
+by its own license file at `skills/sbp-brandbook/LICENSE`, not by the
+Apache 2.0 License that covers the rest of this repository.
+
+Specifically, the Schuberg Philis logo, wordmark, color palette,
+typography specification, and graphic asset library are trademarks
+and proprietary visual assets of Schuberg Philis and may not be
+redistributed, rehosted, or used outside of work for Schuberg Philis
+without prior written permission.
+
+All other directories, files, and contributions to this repository
+are offered under the Apache License, Version 2.0 unless a directory
+contains its own LICENSE file stating otherwise.

--- a/README.md
+++ b/README.md
@@ -297,4 +297,6 @@ Just write a markdown file and place it in `baseline/commands/` (for everyone) o
 
 ## License
 
-MIT
+Apache License 2.0 — see [LICENSE](./LICENSE).
+
+**Exception:** `skills/sbp-brandbook/` is proprietary to Schuberg Philis and is **not** covered by the Apache 2.0 license. It has its own terms at [`skills/sbp-brandbook/LICENSE`](./skills/sbp-brandbook/LICENSE). The Schuberg Philis logo, wordmark, color palette, typography, and SVG brand assets may not be redistributed or used outside of work for Schuberg Philis. See [NOTICE](./NOTICE) for full details.

--- a/skills/sbp-brandbook/LICENSE
+++ b/skills/sbp-brandbook/LICENSE
@@ -1,0 +1,51 @@
+SBP Brand Content License
+=========================
+
+Copyright (c) Schuberg Philis. All rights reserved.
+
+The content in this directory (`skills/sbp-brandbook/`), including but not
+limited to the SKILL.md instructions, SVG graphic assets in `assets/`, the
+Schuberg Philis logo, color system, typography specification, and any
+referenced brand guidelines, is the proprietary intellectual property of
+Schuberg Philis.
+
+This content is NOT covered by the Apache License 2.0 that applies to the
+rest of this repository. Those open-source terms do not extend to this
+directory.
+
+Permitted use
+-------------
+
+- Employees of Schuberg Philis may use these materials in the course of
+  their work for Schuberg Philis.
+- Authorized contractors and partners may use these materials solely for
+  the purpose of delivering work to Schuberg Philis under an applicable
+  agreement.
+- AI coding agents operating on behalf of the above users may load and
+  apply this skill when building assets for Schuberg Philis.
+
+Prohibited use without prior written permission from Schuberg Philis
+--------------------------------------------------------------------
+
+- Redistribution, sublicensing, rehosting, or public republishing of any
+  content from this directory outside of this repository.
+- Use of the Schuberg Philis logo, name, wordmark, color palette, or
+  visual system for any purpose unrelated to Schuberg Philis, including
+  personal projects, third-party products, or derivative brand systems.
+- Modification of the logo, color system, or typography in ways that
+  misrepresent the Schuberg Philis brand or imply endorsement.
+- Training, fine-tuning, or evaluation of external AI models on this
+  content.
+
+Trademarks
+----------
+
+"Schuberg Philis", the Schuberg Philis logo, and the SBP wordmark are
+trademarks of Schuberg Philis. Nothing in this repository grants any
+right to use those trademarks except as permitted above.
+
+Contact
+-------
+
+For licensing inquiries, partnership requests, or permission to use the
+brand outside the terms above, contact the Schuberg Philis marketing team.

--- a/skills/sbp-brandbook/SKILL.md
+++ b/skills/sbp-brandbook/SKILL.md
@@ -5,7 +5,14 @@ metadata:
   domain: brand
   lifecycle: build
   source: https://brandbook.schubergphilis.com/8d157b10c/p/142798-our-brand-book
+  license: proprietary
 ---
+
+> **License notice:** This skill and all assets under `assets/` are the
+> proprietary intellectual property of Schuberg Philis and are **not**
+> covered by the Apache 2.0 license that applies to the rest of this
+> repository. See `skills/sbp-brandbook/LICENSE` for terms. Do not
+> redistribute or use outside of work for Schuberg Philis.
 
 # SBP Brand — Full Spec
 


### PR DESCRIPTION
## Summary

Excludes the SBP brand skill from the repo's Apache 2.0 license and marks it as proprietary Schuberg Philis IP.

- Adds `skills/sbp-brandbook/LICENSE` — proprietary terms with clear permitted / prohibited use, trademark notice, and contact for licensing inquiries
- Adds root `NOTICE` — points at the exclusion so anyone reading the root LICENSE sees the scope carve-out up front
- Adds a license notice block at the top of the brandbook `SKILL.md` and a `license: proprietary` metadata field
- Updates the README's License section: corrects the stale \"MIT\" claim to Apache 2.0 (matches the actual `LICENSE` file) and calls out the brand exclusion

## Why

The brand skill (logo, wordmark, color palette, typography spec, 22 SVG brand assets) is proprietary Schuberg Philis IP. Shipping it under the repo's Apache 2.0 license would implicitly grant the public permission to redistribute and reuse the SBP visual identity. The per-directory LICENSE + root NOTICE pattern is the standard way to carve this out in mixed-license repos (same pattern Anthropic's skills repo uses for some of its skills).

Apache 2.0 still applies to everything else in the repo (CLI, packs, baseline, all non-brand skills).

## Test plan

- [x] `cat skills/sbp-brandbook/LICENSE` — terms are readable and unambiguous
- [x] `cat NOTICE` — root notice points correctly at the exclusion
- [x] README License section reads coherently and corrects MIT → Apache 2.0
- [x] `skills/sbp-brandbook/SKILL.md` shows the license notice block near the top so agents loading the skill can see the usage constraints
- [x] No other SKILL.md files were accidentally marked proprietary