### PR TITLE
Add verify-before-done and design-first skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Skills load on demand — they're not in context unless you invoke them. Pick wh
 | **threat-model** | Structured threat modeling — assets, threat actors, attack surfaces, mitigations, prioritized actions |
 | **agent-architecture-review** | Review multi-agent system designs against a three-layer reference model (guardian/orchestration/worker) |
 | **test-planning** | Design comprehensive test coverage before implementation — behaviors, boundary cases, failure modes, right test type for each |
+| **design-first** | Understand what you're building before you build it — clarify the problem, explore alternatives, assess blast radius, get alignment |
 
 **Building:**
 
@@ -171,6 +172,7 @@ Skills load on demand — they're not in context unless you invoke them. Pick wh
 | **dependency-audit** | Analyze dependencies for bloat, supply-chain risk, and unused packages |
 | **explain-codebase** | Deep explanation of unfamiliar code — traces data flow, names patterns, explains design decisions |
 | **why-we-do-this** | Explain the reasoning behind SBP conventions — connects rules to real failure modes |
+| **verify-before-done** | Prove your work is done before claiming it — run the command, read the output, show the evidence |
 
 **Running:**
 

--- a/WHY.md
+++ b/WHY.md
@@ -51,6 +51,7 @@ The agent challenges before you've written a line. "What's the blast radius? Who
 | `architecture-review` | Single points of failure, observability, operational readiness |
 | `threat-model` | Attack surfaces, mitigations, risk matrix |
 | `agent-architecture-review` | Multi-agent system design against the three-layer model |
+| `design-first` | Understand the problem, explore alternatives, get alignment before building |
 
 ### Build
 
@@ -64,6 +65,7 @@ The agent auto-reviews its own output — silent failures, missing error handlin
 | `dependency-audit` | Supply-chain risk, bloat, unused packages |
 | `explain-codebase` | Deep dive into architecture, patterns, design decisions |
 | `why-we-do-this` | The reasoning behind SBP conventions |
+| `verify-before-done` | Prove it works before claiming it — evidence, not assertions |
 
 ### Run
 

--- a/skills/debug-investigation/SKILL.md
+++ b/skills/debug-investigation/SKILL.md
@@ -54,6 +54,8 @@ Distinguish the *cause* from the *trigger*. The trigger is what makes it happen 
 
 Beware the first hypothesis that fits. Ask: does this explanation account for every symptom, including the ones that do not fit my first theory? If not, keep digging.
 
+If you have tried three or more fixes and none have worked, stop. You are likely treating symptoms, not the cause. Step back and question whether the architecture itself is the problem — a missing abstraction, a wrong boundary, a flawed assumption baked into the design. The fourth fix attempt on the wrong model will fail like the first three.
+
 ## Step 4: Write the regression test first
 
 Before writing the fix, write a test that reproduces the bug and fails because of it.

--- a/skills/design-first/SKILL.md
+++ b/skills/design-first/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: design-first
+description: Understand what you are building before you build it — clarify the problem, explore alternatives, assess blast radius, and get alignment. Use before starting any non-trivial feature, system change, or architecture decision where building the wrong thing is more expensive than thinking first.
+metadata:
+  domain: cross-cutting
+  lifecycle: plan
+---
+
+# Design First
+
+The most expensive line of code is the one that solves the wrong problem. This skill is a thinking discipline — not a process, not a template, not a gate. It ensures you understand what you are building, why, and what alternatives exist before you write code.
+
+## When to use this
+
+- Building a feature that touches multiple components.
+- Making an architecture decision that is hard to reverse.
+- Solving a problem where the solution is not obvious.
+- Starting work where the requirements are fuzzy or assumptions are untested.
+
+Skip this for trivial changes, bug fixes with clear root causes, or mechanical refactors. Not everything needs a design phase — but everything that can go expensively wrong does.
+
+## Step 1: State the problem, not the solution
+
+Before proposing how to build something, answer:
+
+- **What problem are we solving?** State it as a user or system need, not as an implementation.
+- **Why now?** What is the cost of not solving it? What triggered this work?
+- **What is the blast radius?** Which systems, teams, and customers are affected if this goes wrong?
+- **What are the non-goals?** What are you explicitly *not* doing? Boundaries prevent scope creep.
+
+If any answer is "I'm not sure," that is the thing to resolve first — not in code, but in conversation.
+
+## Step 2: Explore alternatives
+
+When the path forward is not obvious, propose 2-3 approaches before committing to one.
+
+For each approach:
+
+- **What does it look like?** One paragraph describing the approach.
+- **What does it give us?** The main benefit.
+- **What does it cost?** Complexity, risk, time, dependencies.
+- **What could go wrong?** The failure mode specific to this approach.
+
+You do not need a formal document. A bulleted list in the PR description, a thread in Slack, or a conversation with a colleague is enough. The point is to think before building, not to produce paperwork.
+
+If only one approach is viable, say so and explain why the alternatives do not work. That reasoning is the design.
+
+## Step 3: Identify what you do not know
+
+Every design has assumptions. Name them:
+
+- **Technical assumptions**: "The database can handle this query volume." "This API is idempotent." "The message queue preserves ordering."
+- **Domain assumptions**: "Users always provide an email." "This process runs once per day." "The upstream service is available."
+- **Organizational assumptions**: "The other team will accept this interface." "We can deploy independently." "This does not need a change request."
+
+For each assumption, decide: can you verify it now (and should you), or is it safe to proceed and validate later?
+
+Assumptions you cannot verify and cannot afford to be wrong about are the highest-risk items. Address those first.
+
+## Step 4: Get alignment
+
+Before writing code, confirm your understanding with the people who will be affected:
+
+- Does the person who requested this agree with the problem statement?
+- Does the team agree on the approach (or at least understand the trade-offs)?
+- Does the on-call engineer know what changes are coming to their system?
+
+Alignment does not require a meeting. A message saying "I'm planning to do X because Y, with approach Z — does that sound right?" is often enough.
+
+The goal is not consensus. The goal is that no one is surprised by what you build or how you build it.
+
+## What this is not
+
+- **Not a design document template.** Write what is useful, skip what is not.
+- **Not a gate.** There is no approval process. This is a thinking habit, not a workflow.
+- **Not for everything.** A one-line config change does not need a design phase. Use judgment.
+
+## Closing notes
+
+Senior engineers do this instinctively — they think through the problem, consider alternatives, check assumptions, and align with stakeholders before writing code. This skill makes that instinct explicit so it happens consistently, especially under pressure when the temptation to "just start building" is strongest.
+
+The time spent understanding the problem is never wasted. The time spent building the wrong solution always is.

--- a/skills/verify-before-done/SKILL.md
+++ b/skills/verify-before-done/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: verify-before-done
+description: Prove your work is done before claiming it — run the command, read the output, show the evidence. Use before any completion claim, commit, or handoff in mission-critical systems where "it should work" is not an acceptable answer.
+metadata:
+  domain: cross-cutting
+  lifecycle: build
+---
+
+# Verify Before Done
+
+In mission-critical systems, "it should work" is not evidence. "Here is the test output with 0 failures" is evidence. This skill enforces a simple discipline: before claiming anything is done, prove it.
+
+## The rule
+
+Every completion claim must follow this sequence:
+
+1. **Identify** — what command proves this claim? ("tests pass" → run the test suite. "Bug is fixed" → run the regression test. "Feature works" → exercise it end-to-end.)
+2. **Run** — execute the full command. Not a partial run, not a cached result, not "it passed earlier." Fresh, complete, now.
+3. **Read** — read the full output. Check exit codes. Count failures. Look for warnings you are about to ignore.
+4. **Confirm** — does the output actually support the claim? "95 passed, 2 failed" does not support "tests pass."
+5. **Show** — include the evidence with the claim. The output is the proof.
+
+Only then make the claim.
+
+## What counts as a claim
+
+Any statement that work is complete:
+
+- "Tests pass."
+- "The bug is fixed."
+- "The feature is working."
+- "Ready for review."
+- "Build succeeds."
+- "No regressions."
+
+Each requires its own evidence. "Tests pass" does not prove "no regressions" if you only ran unit tests and the integration suite exists.
+
+## Words that signal you are guessing
+
+If you catch yourself using these, stop and run the command:
+
+- "should" — "tests *should* pass"
+- "probably" — "this *probably* works"
+- "seems to" — "it *seems to* be fixed"
+- "looks good" — no it does not, you have not checked
+- "I think" — thinking is not verifying
+
+## Why this matters
+
+A false completion claim is expensive in mission-critical systems:
+
+- A "fixed" bug that is not fixed erodes trust and wastes the next person's time.
+- A "passing" test suite that has failures trains the team to ignore red.
+- A "ready for review" PR that does not build wastes the reviewer's time and yours.
+- A "deployed" service that is not actually healthy pages someone at 3 AM.
+
+The cost of running one more command is seconds. The cost of a false claim is hours, trust, or an incident.
+
+## Common verification gaps
+
+- **Ran unit tests, skipped integration tests.** If both exist, both must pass.
+- **Checked the happy path, skipped the error path.** If the fix touches error handling, exercise the error.
+- **Verified locally, not in CI.** Local and CI environments diverge. If CI matters, check CI.
+- **Read the first line of output, not the last.** Failures often appear at the end. Read the whole thing.
+- **Trusted a previous run.** Code changed since then. Run it again.
+
+## Closing notes
+
+This is not bureaucracy. This is the difference between "I believe it works" and "I know it works." In systems where people get paged, that difference matters.
+
+Run the command. Read the output. Show the evidence. Then say it is done.


### PR DESCRIPTION
## Summary

Cherry-picked the best ideas from the [superpowers](https://github.com/obra/superpowers) skill set and adapted them with SBP's mission-critical voice:

- **`verify-before-done`** — New skill. Evidence before assertions: every completion claim ("tests pass", "bug is fixed", "ready for review") must be backed by actual command output. Flags weasel words ("should", "probably", "seems to"). Covers common verification gaps.
- **`design-first`** — New skill. Thinking discipline for non-trivial work: state the problem (not the solution), explore 2-3 alternatives with trade-offs, name your assumptions, get alignment before writing code. Not a template or gate — a habit.
- **`debug-investigation`** — Added "3+ fixes failed → question the architecture" heuristic to Step 3.
- **README.md** and **WHY.md** — Added new skills to the relevant tables.

### What we took and what we left

| Superpowers concept | Action | Reasoning |
|---|---|---|
| Verification before completion | **Adapted** as `verify-before-done` | Real gap — no sbp-skills addressed false completion claims |
| Design-first / brainstorming gate | **Adapted** as `design-first` | Valuable principle, stripped the ceremony |
| "3+ fixes → question architecture" | **Absorbed** into `debug-investigation` | Sharp heuristic, two lines |
| TDD discipline | **Skipped** | `feature-development` already covers this better |
| Systematic debugging | **Skipped** | `debug-investigation` already equivalent |
| Writing/executing plans pipeline | **Skipped** | Too prescriptive for senior engineers |
| Branch completion workflow | **Skipped** | Too simple for a full skill |

## Test plan

- [x] `python3 -m pytest tests/ -v` — 52 tests pass
- [x] CLI validator passes for both new skills
- [x] New skills follow SKILL.md format (YAML frontmatter, agentskills.io spec)
- [x] Review skill content for SBP voice consistency
- [x] Try `design-first` and `verify-before-done` in a real conversation