### PR TITLE
Add Terraform pack + terraform/mcaf-module/review-mcaf skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,10 @@ Packs activate automatically based on your project's files. They encode *how SBP
 | Pack | Auto-detected by | What it covers |
 |------|-----------------|----------------|
 | **python** | `pyproject.toml`, `setup.py`, `requirements.txt` | uv, ruff, pyright, pytest — auditable, testable Python for production |
+| **terraform** | `*.tf`, `terraform.tf`, `versions.tf` | Module layout, version ranges, `optional(…)`, curated outputs, `local.tags`, native `terraform test` |
 | **supply-chain** | `.github/workflows/*.yml` | Pin GitHub Actions to SHA — prevent compromised dependencies in CI/CD |
 
-More packs coming: terraform, kubernetes, docker, github-actions.
+More packs coming: kubernetes, docker, github-actions.
 
 ### Skills — deeper workflows for when you need them
 
@@ -182,6 +183,14 @@ Skills load on demand — they're not in context unless you invoke them. Pick wh
 | **runbook-author** | Generate operational runbooks from code and infrastructure — optimized for the 3 AM scenario |
 | **observability-check** | Verify monitoring, alerting, and logging coverage across the four pillars |
 
+**Terraform / MCAF:**
+
+| Skill | What it does |
+|-------|-------------|
+| **terraform** | Generic Terraform/OpenTofu authoring — module structure, variable + output design, block ordering, version pinning, native `terraform test`, CI/CD, security scanning, and state hygiene |
+| **mcaf-module** | Schuberg Philis MCAF-specific deltas (filenames, provider floors, `mcaf-github-workflows` reuse, `local.tags` with `ManagedBy`, release flow). Bundles `GUIDE.md`, the authoritative source |
+| **review-mcaf** | Qualitative MCAF module review that produces a good/bad/verdict markdown report; for many modules, dispatches parallel subagents and stitches one file |
+
 **Brand:**
 
 | Skill | What it does |
@@ -196,6 +205,104 @@ sbp-skills enable threat-model
 
 # Or manually — just copy the folder
 cp -r skills/threat-model ~/.claude/skills/
+```
+
+---
+
+## Terraform & MCAF
+
+Three-layer coverage for anything Terraform at Schuberg Philis — a daily-context pack plus three opt-in skills that stack on top of each other. You reach for whichever layer matches what you're doing.
+
+### How the layers stack
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│  packs/terraform/    always-on context (AGENTS.md, CLAUDE.md) │
+│                      → activated when any *.tf is in the repo │
+└───────────────────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────┐
+│  skills/terraform/     generic Terraform / OpenTofu baseline  │
+│          ↑ layered on top                                     │
+│  skills/mcaf-module/   MCAF-specific deltas (+ GUIDE.md)      │
+│          ↑ layered on top                                     │
+│  skills/review-mcaf/   qualitative good/bad/verdict review    │
+└───────────────────────────────────────────────────────────────┘
+```
+
+- The **pack** lives in `AGENTS.md` / `CLAUDE.md`, so baseline rules (file layout, version ranges, `local.tags`, curated outputs) are always in context when editing a Terraform repo.
+- The **skills** load on demand when the agent decides they apply, or when you explicitly invoke them. They contain the long-form reference material the pack points at.
+
+### What each piece covers
+
+| Piece | Type | Triggers on | What you get |
+|---|---|---|---|
+| **`packs/terraform`** | pack | `*.tf`, `terraform.tf`, `versions.tf` | Tight 276-word AGENTS.md fragment — layout, pinning, variable/output rules, tag pattern, acceptance criteria |
+| **`skills/terraform`** | skill | Any Terraform/OpenTofu authoring or review | Module structure, block ordering, `optional(…)`, testing decision matrix, CI/CD shape, security scanning, state hygiene. Includes `references/`: `module-patterns.md`, `code-patterns.md`, `testing.md`, `ci-cd.md`, `security-compliance.md`, `quick-reference.md` |
+| **`skills/mcaf-module`** | skill | `terraform-<provider>-mcaf-<name>` repos | MCAF deltas: `terraform.tf` not `versions.tf`, provider floors (AWS ≥6, Azurerm ≥4, …), `mcaf-github-workflows` reuse, `local.tags` with `ManagedBy`, native `terraform test` with `mock_provider`, conventional-commit labels, release-drafter flow, corpus-specific anti-patterns. Bundles **`GUIDE.md`** — the authoritative way-of-working distilled from 91 MCAF modules |
+| **`skills/review-mcaf`** | skill | "review this MCAF module", "is `terraform-<provider>-mcaf-<name>` any good?" | Qualitative review producing a good/bad/verdict markdown report. For multiple modules, dispatches parallel subagents and stitches one file |
+
+### Common workflows
+
+**Editing a Terraform repo (any org):**
+
+```bash
+# Inside a repo with *.tf files
+sbp-skills init       # → terraform pack auto-activates, AGENTS.md updated
+sbp-skills enable terraform   # optional: pull in the deep reference skill
+```
+
+**Authoring or reviewing an MCAF module:**
+
+```bash
+sbp-skills enable terraform
+sbp-skills enable mcaf-module
+# Now the agent knows the generic rules AND the MCAF-specific overlay,
+# with GUIDE.md bundled for citation.
+```
+
+Then in the agent: "create a new `terraform-aws-mcaf-<thing>` module" or "review this PR against MCAF rules". The `mcaf-module` skill applies automatically when it sees an MCAF repo name or file.
+
+**Running a qualitative MCAF review (single repo or many):**
+
+```bash
+sbp-skills enable review-mcaf
+```
+
+Then in the agent: `review this MCAF module` (current dir), or `review all MCAF modules in ./repos` (dispatches subagents and stitches a single report).
+
+### Layering rules
+
+- The pack contains the *minimum* set of rules every Terraform repo needs. Don't duplicate its content in the skills.
+- `mcaf-module` references `terraform` for anything generic — only the MCAF-specific *delta* lives there.
+- `review-mcaf` cites `../mcaf-module/GUIDE.md §N` for every rule it applies. It doesn't re-state rules; it tells the agent how to *apply* them.
+- `GUIDE.md` is the single source of truth for MCAF rules. Any new rule lands there first, then the skills reference it.
+
+### Keeping content current
+
+The Terraform + MCAF skills are developed in a separate repo (`mcaf-review`) while under active iteration — the corpus analysis, `GUIDE.md`, and the skills themselves live there. A one-command sync pulls the latest into this repo:
+
+```bash
+# Default source: ~/git/schuberg/mcaf-review
+scripts/sync-terraform-skills.sh
+
+# Custom source path
+MCAF_REVIEW_DIR=/path/to/mcaf-review scripts/sync-terraform-skills.sh
+
+# Dry-run — show drift without writing
+scripts/sync-terraform-skills.sh --check
+```
+
+The script is idempotent. It copies the three skills + `GUIDE.md` and rewrites a handful of `GUIDE.md` path references in `review-mcaf`/`mcaf-module` so cross-skill links resolve once they're symlinked as siblings under `~/.claude/skills/`. See [`scripts/README.md`](scripts/README.md) for details.
+
+**Source-of-truth rule:**
+
+- Generic Terraform + MCAF content (skills + `GUIDE.md`) → edit in `mcaf-review`, run the sync script.
+- The `terraform` *pack* (AGENTS.md / CLAUDE.md / manifest) → edit directly in this repo; not synced from anywhere.
+
+Validate after any sync or manual edit:
+
+```bash
+python3 cli/sbp-skills validate packs/terraform skills/terraform skills/mcaf-module skills/review-mcaf
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Packs activate automatically based on your project's files. They encode *how SBP
 | Pack | Auto-detected by | What it covers |
 |------|-----------------|----------------|
 | **python** | `pyproject.toml`, `setup.py`, `requirements.txt` | uv, ruff, pyright, pytest — auditable, testable Python for production |
-| **terraform** | `*.tf`, `terraform.tf`, `versions.tf` | Module layout, version ranges, `optional(…)`, curated outputs, `local.tags`, native `terraform test` |
+| **terraform** | `*.tf`, `terraform.tf`, `versions.tf` | Module layout, version ranges, `optional(…)`, curated outputs, native `terraform test` |
 | **supply-chain** | `.github/workflows/*.yml` | Pin GitHub Actions to SHA — prevent compromised dependencies in CI/CD |
 
 More packs coming: kubernetes, docker, github-actions.
@@ -188,7 +188,7 @@ Skills load on demand — they're not in context unless you invoke them. Pick wh
 | Skill | What it does |
 |-------|-------------|
 | **terraform** | Generic Terraform/OpenTofu authoring — module structure, variable + output design, block ordering, version pinning, native `terraform test`, CI/CD, security scanning, and state hygiene |
-| **mcaf-module** | Schuberg Philis MCAF-specific deltas (filenames, provider floors, `mcaf-github-workflows` reuse, `local.tags` with `ManagedBy`, release flow). Bundles `GUIDE.md`, the authoritative source |
+| **mcaf-module** | Schuberg Philis MCAF-specific deltas (filenames, provider floors, `mcaf-github-workflows` reuse, release flow). Bundles `GUIDE.md`, the authoritative source |
 | **review-mcaf** | Qualitative MCAF module review that produces a good/bad/verdict markdown report; for many modules, dispatches parallel subagents and stitches one file |
 
 **Brand:**
@@ -229,7 +229,7 @@ Three-layer coverage for anything Terraform at Schuberg Philis — a daily-conte
 └───────────────────────────────────────────────────────────────┘
 ```
 
-- The **pack** lives in `AGENTS.md` / `CLAUDE.md`, so baseline rules (file layout, version ranges, `local.tags`, curated outputs) are always in context when editing a Terraform repo.
+- The **pack** lives in `AGENTS.md` / `CLAUDE.md`, so baseline rules (file layout, version ranges, curated outputs) are always in context when editing a Terraform repo.
 - The **skills** load on demand when the agent decides they apply, or when you explicitly invoke them. They contain the long-form reference material the pack points at.
 
 ### What each piece covers
@@ -238,7 +238,7 @@ Three-layer coverage for anything Terraform at Schuberg Philis — a daily-conte
 |---|---|---|---|
 | **`packs/terraform`** | pack | `*.tf`, `terraform.tf`, `versions.tf` | Tight 276-word AGENTS.md fragment — layout, pinning, variable/output rules, tag pattern, acceptance criteria |
 | **`skills/terraform`** | skill | Any Terraform/OpenTofu authoring or review | Module structure, block ordering, `optional(…)`, testing decision matrix, CI/CD shape, security scanning, state hygiene. Includes `references/`: `module-patterns.md`, `code-patterns.md`, `testing.md`, `ci-cd.md`, `security-compliance.md`, `quick-reference.md` |
-| **`skills/mcaf-module`** | skill | `terraform-<provider>-mcaf-<name>` repos | MCAF deltas: `terraform.tf` not `versions.tf`, provider floors (AWS ≥6, Azurerm ≥4, …), `mcaf-github-workflows` reuse, `local.tags` with `ManagedBy`, native `terraform test` with `mock_provider`, conventional-commit labels, release-drafter flow, corpus-specific anti-patterns. Bundles **`GUIDE.md`** — the authoritative way-of-working distilled from 91 MCAF modules |
+| **`skills/mcaf-module`** | skill | `terraform-<provider>-mcaf-<name>` repos | MCAF deltas: `terraform.tf` not `versions.tf`, provider floors (AWS ≥6, Azurerm ≥4, …), `mcaf-github-workflows` reuse, native `terraform test` with `mock_provider`, conventional-commit labels, release-drafter flow, corpus-specific anti-patterns. Bundles **`GUIDE.md`** — the authoritative way-of-working distilled from 91 MCAF modules |
 | **`skills/review-mcaf`** | skill | "review this MCAF module", "is `terraform-<provider>-mcaf-<name>` any good?" | Qualitative review producing a good/bad/verdict markdown report. For multiple modules, dispatches parallel subagents and stitches one file |
 
 ### Common workflows

--- a/detection.toml
+++ b/detection.toml
@@ -13,11 +13,11 @@ pack = "dotnet"
 files = [".github/workflows/*.yml", ".github/workflows/*.yaml"]
 pack = "supply-chain"
 
+[terraform]
+files = ["*.tf", "terraform.tf", "versions.tf"]
+pack = "terraform"
+
 # Uncomment when packs are created:
-# [terraform]
-# files = ["*.tf"]
-# pack = "terraform"
-#
 # [docker]
 # files = ["Dockerfile", "docker-compose.yml", "docker-compose.yaml"]
 # pack = "docker"

--- a/packs/terraform/AGENTS.md
+++ b/packs/terraform/AGENTS.md
@@ -1,0 +1,24 @@
+## Terraform / OpenTofu Conventions
+
+Baseline rules for any Terraform/OpenTofu module. For MCAF specifics, enable the `mcaf-module` skill.
+
+**Layout:** `main.tf`, `variables.tf`, `outputs.tf`, `terraform.tf` (not `versions.tf`). `locals.tf` / `data.tf` only when non-empty. Examples under `examples/<scenario>/`, native tests under `tests/`.
+
+**Version pinning:** `required_version = ">= X.Y"` — floor only, no upper bound. Provider versions as a range `">= X.0, < (X+1).0"`. Never pin providers exactly or patch-tight inside a reusable module.
+
+**Variables:** every variable has `type` + `description`. Arg order: `type` → `default` → `description` → `nullable` → `sensitive` → `validation`. Prefer `optional(field, default)` over flat sprawl. `sensitive = true` on secrets. `default = null` (not `""`) for unset. Snake_case; booleans read as statements (`versioning`, not `enable_versioning`).
+
+**Outputs:** every output has `description`. Lead with `id`, `arn`, `name`. Never `output "resource" { value = aws_x.default }` — curate. Mark credentials `sensitive = true`.
+
+**Tags:** `variable "tags"` + `locals.tags = merge(var.tags, { ManagedBy = "Terraform" })`. Reference `local.tags` on every taggable resource. No `try(var.tags)` cargo-cult.
+
+**Testing:** prefer native `terraform test` with `mock_provider` — no cloud credentials needed. Tests under `tests/`. Cover each conditional branch plus negative paths with `expect_failures`. Reach for Terratest only when real apply is required.
+
+**State & secrets:** remote backend with locking and encryption. Modules take ARNs/IDs, not plaintext secrets. Run `checkov` (or `tfsec`/`trivy`) in pre-commit + CI; skip rules only with an inline rationale.
+
+**Acceptance criteria:**
+- [ ] `terraform fmt -check -recursive` passes
+- [ ] `tflint` passes on root + every example
+- [ ] `terraform validate` passes per example
+- [ ] `terraform test` passes (or justify why absent)
+- [ ] No whole-resource outputs, no hard provider pins, no plaintext secret defaults

--- a/packs/terraform/AGENTS.md
+++ b/packs/terraform/AGENTS.md
@@ -4,21 +4,22 @@ Baseline rules for any Terraform/OpenTofu module. For MCAF specifics, enable the
 
 **Layout:** `main.tf`, `variables.tf`, `outputs.tf`, `terraform.tf` (not `versions.tf`). `locals.tf` / `data.tf` only when non-empty. Examples under `examples/<scenario>/`, native tests under `tests/`.
 
-**Version pinning:** `required_version = ">= X.Y"` — floor only, no upper bound. Provider versions as a range `">= X.0, < (X+1).0"`. Never pin providers exactly or patch-tight inside a reusable module.
+**Version pinning:** `required_version = ">= X.Y"` — floor only, no upper bound. Never pin providers exactly or patch-tight inside a reusable module.
 
 **Variables:** every variable has `type` + `description`. Arg order: `type` → `default` → `description` → `nullable` → `sensitive` → `validation`. Prefer `optional(field, default)` over flat sprawl. `sensitive = true` on secrets. `default = null` (not `""`) for unset. Snake_case; booleans read as statements (`versioning`, not `enable_versioning`).
 
 **Outputs:** every output has `description`. Lead with `id`, `arn`, `name`. Never `output "resource" { value = aws_x.default }` — curate. Mark credentials `sensitive = true`.
 
-**Tags:** `variable "tags"` + `locals.tags = merge(var.tags, { ManagedBy = "Terraform" })`. Reference `local.tags` on every taggable resource. No `try(var.tags)` cargo-cult.
+**Tags:** `variable "tags"`. Reference `var.tags` on every taggable resource. No `try(var.tags)` cargo-cult.
 
-**Testing:** prefer native `terraform test` with `mock_provider` — no cloud credentials needed. Tests under `tests/`. Cover each conditional branch plus negative paths with `expect_failures`. Reach for Terratest only when real apply is required.
+**Testing:** prefer native `terraform test` with `mock_provider` — no cloud credentials needed. Tests under `tests/`. Cover each conditional branch plus negative paths with `expect_failures`.
 
-**State & secrets:** remote backend with locking and encryption. Modules take ARNs/IDs, not plaintext secrets. Run `checkov` (or `tfsec`/`trivy`) in pre-commit + CI; skip rules only with an inline rationale.
+**State & secrets:** remote backend with locking and encryption. Modules take ARNs/IDs, not plaintext secrets. Run `checkov` in pre-commit + CI; skip rules only with an inline rationale.
 
 **Acceptance criteria:**
 - [ ] `terraform fmt -check -recursive` passes
 - [ ] `tflint` passes on root + every example
 - [ ] `terraform validate` passes per example
 - [ ] `terraform test` passes (or justify why absent)
+- [ ] `checkov` passes (skip rules only with inline rationale)
 - [ ] No whole-resource outputs, no hard provider pins, no plaintext secret defaults

--- a/packs/terraform/CLAUDE.md
+++ b/packs/terraform/CLAUDE.md
@@ -1,0 +1,11 @@
+## Terraform — Claude Code
+
+For deeper guidance, invoke the skills:
+
+- `terraform` — generic Terraform/OpenTofu authoring (module structure, `optional(…)`, block ordering, testing decision matrix, CI/CD shape).
+- `mcaf-module` — Schuberg Philis MCAF deltas (shared workflows, `local.tags` with `ManagedBy`, native tests with `mock_provider`, corpus-specific anti-patterns). Bundles `GUIDE.md`, the authoritative source for every MCAF rule.
+- `review-mcaf` — qualitative MCAF module review that produces a good/bad/verdict markdown report.
+
+Prefer `terraform test` (native) over Terratest — runs without cloud credentials via `mock_provider`. Tests live under `tests/`, never `test/` or `terratest/`.
+
+When asked for an MCAF review of one or more `terraform-<provider>-mcaf-<name>` repos, use the `review-mcaf` skill — for many repos it dispatches parallel subagents and stitches a single report.

--- a/packs/terraform/CLAUDE.md
+++ b/packs/terraform/CLAUDE.md
@@ -3,7 +3,7 @@
 For deeper guidance, invoke the skills:
 
 - `terraform` — generic Terraform/OpenTofu authoring (module structure, `optional(…)`, block ordering, testing decision matrix, CI/CD shape).
-- `mcaf-module` — Schuberg Philis MCAF deltas (shared workflows, `local.tags` with `ManagedBy`, native tests with `mock_provider`, corpus-specific anti-patterns). Bundles `GUIDE.md`, the authoritative source for every MCAF rule.
+- `mcaf-module` — Schuberg Philis MCAF deltas (shared workflows, native tests with `mock_provider`, corpus-specific anti-patterns). Bundles `GUIDE.md`, the authoritative source for every MCAF rule.
 - `review-mcaf` — qualitative MCAF module review that produces a good/bad/verdict markdown report.
 
 Prefer `terraform test` (native) over Terratest — runs without cloud credentials via `mock_provider`. Tests live under `tests/`, never `test/` or `terratest/`.

--- a/packs/terraform/README.md
+++ b/packs/terraform/README.md
@@ -1,0 +1,26 @@
+# Terraform Convention Pack
+
+Mission-critical Terraform/OpenTofu conventions for Schuberg Philis projects.
+
+## What this activates
+
+- **Module layout** — `terraform.tf` over `versions.tf`, examples under `examples/`, native tests under `tests/`
+- **Version pinning** — floor-only `required_version`, provider version ranges (never exact or patch-tight)
+- **Variable/output design** — `type` + `description` on every var, `optional(…)` over flat sprawl, curated outputs, `sensitive = true` on secrets
+- **Tag hygiene** — `locals.tags = merge(var.tags, { ManagedBy = "Terraform" })`
+- **Testing** — native `terraform test` with `mock_provider`
+- **Security** — checkov/tfsec/trivy in pre-commit + CI, no plaintext secret defaults
+
+## Auto-detected by
+
+- `*.tf`
+- `terraform.tf`
+- `versions.tf`
+
+## Related skills
+
+Enable with `sbp-skills enable <skill>`:
+
+- `terraform` — generic Terraform/OpenTofu reference (with `references/` — module patterns, code patterns, testing, CI/CD, security, quick reference)
+- `mcaf-module` — Schuberg Philis MCAF-specific rules (bundles the `GUIDE.md` way-of-working)
+- `review-mcaf` — qualitative MCAF module review that produces good/bad/verdict reports

--- a/packs/terraform/README.md
+++ b/packs/terraform/README.md
@@ -7,9 +7,9 @@ Mission-critical Terraform/OpenTofu conventions for Schuberg Philis projects.
 - **Module layout** — `terraform.tf` over `versions.tf`, examples under `examples/`, native tests under `tests/`
 - **Version pinning** — floor-only `required_version`, provider version ranges (never exact or patch-tight)
 - **Variable/output design** — `type` + `description` on every var, `optional(…)` over flat sprawl, curated outputs, `sensitive = true` on secrets
-- **Tag hygiene** — `locals.tags = merge(var.tags, { ManagedBy = "Terraform" })`
+- **Tag hygiene** — `variable "tags"`. Referencing `var.tags` on every taggable resource.
 - **Testing** — native `terraform test` with `mock_provider`
-- **Security** — checkov/tfsec/trivy in pre-commit + CI, no plaintext secret defaults
+- **Security** — checkov in pre-commit + CI, no plaintext secret defaults
 
 ## Auto-detected by
 

--- a/packs/terraform/manifest.toml
+++ b/packs/terraform/manifest.toml
@@ -1,0 +1,13 @@
+[pack]
+name = "terraform"
+description = "Mission-critical Terraform/OpenTofu: module layout, version ranges, native terraform test, safe state and secrets hygiene"
+version = "1.0.0"
+authors = ["Schuberg Philis"]
+
+[detect]
+files = ["*.tf", "terraform.tf", "versions.tf"]
+
+[targets]
+agents_md = true
+claude_md = true
+commands = false

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,38 @@
+# scripts/
+
+Maintenance scripts.
+
+## `sync-terraform-skills.sh`
+
+One-way sync from `mcaf-review` (source of truth while skills are under active development) into this repo's `skills/`. Run whenever you've edited the skills or `GUIDE.md` in `mcaf-review`.
+
+```bash
+# Default source path: ~/git/schuberg/mcaf-review
+scripts/sync-terraform-skills.sh
+
+# Override source path
+MCAF_REVIEW_DIR=/path/to/mcaf-review scripts/sync-terraform-skills.sh
+
+# Dry-run — show drift without writing
+scripts/sync-terraform-skills.sh --check
+```
+
+The script:
+
+1. Copies `.claude/skills/{terraform,mcaf-module,review-mcaf}/` from `mcaf-review`.
+2. Copies `mcaf-review/GUIDE.md` to `skills/mcaf-module/GUIDE.md` (bundled with the skill so its reference resolves once installed).
+3. Rewrites `GUIDE.md` path references in `review-mcaf/SKILL.md` and `mcaf-module/SKILL.md` so cross-skill links resolve when the skills are symlinked as siblings under `~/.claude/skills/`.
+4. Leaves the pack at `packs/terraform/` untouched — the pack is authored here, not synced from anywhere.
+
+After running, always validate:
+
+```bash
+python3 cli/sbp-skills validate packs/terraform skills/terraform skills/mcaf-module skills/review-mcaf
+```
+
+### Source-of-truth rule
+
+- Generic Terraform + MCAF content → edit in `mcaf-review/.claude/skills/…` and `mcaf-review/GUIDE.md`, then sync.
+- The `terraform` **pack** (AGENTS.md, CLAUDE.md, manifest) → edit in this repo directly; it's not in `mcaf-review`.
+
+If the mcaf-review repo eventually goes away or merges in, drop this script and edit the skills directly here.

--- a/scripts/sync-terraform-skills.sh
+++ b/scripts/sync-terraform-skills.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Sync terraform/mcaf skills from mcaf-review (source of truth while under active
+# development) into sbp-skills.
+#
+# Usage:
+#   scripts/sync-terraform-skills.sh                    # uses $MCAF_REVIEW_DIR or default
+#   MCAF_REVIEW_DIR=/path/to/mcaf-review scripts/sync-terraform-skills.sh
+#   scripts/sync-terraform-skills.sh --check            # dry-run: diff only, no writes
+#
+# The mapping:
+#   mcaf-review/.claude/skills/terraform/      -> sbp-skills/skills/terraform/
+#   mcaf-review/.claude/skills/mcaf-module/    -> sbp-skills/skills/mcaf-module/
+#   mcaf-review/.claude/skills/review-mcaf/    -> sbp-skills/skills/review-mcaf/
+#   mcaf-review/GUIDE.md                       -> sbp-skills/skills/mcaf-module/GUIDE.md
+#
+# After copying, GUIDE.md references in review-mcaf/SKILL.md are rewritten to
+# point at ../mcaf-module/GUIDE.md so cross-skill links resolve once installed.
+
+set -euo pipefail
+
+SRC="${MCAF_REVIEW_DIR:-$HOME/git/schuberg/mcaf-review}"
+DST="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [ ! -d "$SRC/.claude/skills/terraform" ]; then
+  echo "error: source skills not found at $SRC/.claude/skills/terraform" >&2
+  echo "hint:  set MCAF_REVIEW_DIR to the mcaf-review checkout path" >&2
+  exit 1
+fi
+
+CHECK=0
+if [ "${1:-}" = "--check" ]; then
+  CHECK=1
+fi
+
+sync_path() {
+  local from="$1"
+  local to="$2"
+  if [ $CHECK -eq 1 ]; then
+    if ! diff -qr "$from" "$to" >/dev/null 2>&1; then
+      echo "DRIFT $to"
+      diff -r "$from" "$to" || true
+    else
+      echo "OK    $to"
+    fi
+  else
+    mkdir -p "$(dirname "$to")"
+    rm -rf "$to"
+    cp -R "$from" "$to"
+    echo "synced $to"
+  fi
+}
+
+sync_path "$SRC/.claude/skills/terraform"   "$DST/skills/terraform"
+sync_path "$SRC/.claude/skills/mcaf-module" "$DST/skills/mcaf-module"
+sync_path "$SRC/.claude/skills/review-mcaf" "$DST/skills/review-mcaf"
+
+# GUIDE.md is the authoritative source for mcaf-module + review-mcaf.
+# It lives at the mcaf-review repo root; we bundle it with mcaf-module.
+if [ $CHECK -eq 1 ]; then
+  if ! diff -q "$SRC/GUIDE.md" "$DST/skills/mcaf-module/GUIDE.md" >/dev/null 2>&1; then
+    echo "DRIFT $DST/skills/mcaf-module/GUIDE.md"
+  else
+    echo "OK    $DST/skills/mcaf-module/GUIDE.md"
+  fi
+else
+  cp "$SRC/GUIDE.md" "$DST/skills/mcaf-module/GUIDE.md"
+  echo "synced $DST/skills/mcaf-module/GUIDE.md"
+fi
+
+# Rewrite GUIDE.md path references in review-mcaf so cross-skill links resolve
+# once installed as siblings under ~/.claude/skills/ (or wherever the harness
+# symlinks them).
+if [ $CHECK -eq 0 ]; then
+  RMD="$DST/skills/review-mcaf/SKILL.md"
+  MMD="$DST/skills/mcaf-module/SKILL.md"
+
+  # Portable in-place sed (BSD + GNU).
+  sed_i() {
+    if sed --version >/dev/null 2>&1; then sed -i "$@"; else sed -i '' "$@"; fi
+  }
+
+  # review-mcaf: rewrite every `GUIDE.md` codespan — covers `GUIDE.md`,
+  # `GUIDE.md §3`, `GUIDE.md` §X/§Y, etc. Order matters: the trailing-space
+  # variant runs first so the backtick-closed variant doesn't match it.
+  sed_i 's|`GUIDE\.md |`../mcaf-module/GUIDE.md |g' "$RMD"
+  sed_i 's|`GUIDE\.md`|`../mcaf-module/GUIDE.md`|g' "$RMD"
+  sed_i 's|lives in `\.\./mcaf-module/GUIDE\.md`|lives in [`../mcaf-module/GUIDE.md`](../mcaf-module/GUIDE.md)|g' "$RMD"
+  sed_i 's|- `\.\./mcaf-module/GUIDE\.md` — the source of truth|- [`../mcaf-module/GUIDE.md`](../mcaf-module/GUIDE.md) — the source of truth|g' "$RMD"
+
+  # In mcaf-module, GUIDE.md is a sibling file — point link at it directly.
+  sed_i 's|`GUIDE\.md` in this repo|[`GUIDE.md`](GUIDE.md) bundled with this skill|g' "$MMD"
+
+  echo "rewrote GUIDE.md path references in review-mcaf + mcaf-module SKILL.md"
+fi
+
+if [ $CHECK -eq 0 ]; then
+  echo
+  echo "Validate with: python3 cli/sbp-skills validate packs/terraform skills/terraform skills/mcaf-module skills/review-mcaf"
+fi

--- a/skills/mcaf-module/GUIDE.md
+++ b/skills/mcaf-module/GUIDE.md
@@ -65,11 +65,12 @@ terraform {
 
 **Rules:**
 
-- `required_version` — set a **minimum** with `>=`, no upper bound on Terraform itself. The current MCAF floor is **`>= 1.9`** (37% of modules; growing). Anything below `>= 1.7` is legacy and should be bumped next touch.
-- Provider `version` — express both floor and ceiling as **`>= X.Y, < (X+1).0`**. Pinning only with `~>` is accepted but less common. Do NOT pin to an exact version in a module.
-- AWS provider floor is **`>= 6.0`** (adoption: 19/47 AWS modules already on 6.x, another 13 on 5.x with stated intent to bump).
-- Azure provider floor is **`>= 4.0`** (adoption: 18/39 Azure modules).
-- Datadog provider floor is **`>= 3.39`**.
+The exact floor number is not important — what matters is the **bounds**: a floor-only constraint for Terraform and most providers (no upper bound), and a major-version range for AzureAD, Azurerm, and Datadog (floor + upper bound at the next major). Don't bikeshed the minor; just ensure the constraint shape is correct.
+
+- `required_version` — set a **minimum** with `>=`, no upper bound on Terraform itself. Any floor is acceptable (e.g. `">= 1.9"`).
+- Provider `version` — floor-only for most providers; floor + upper bound at the next major for AzureAD, Azurerm, and Datadog. Do NOT pin to an exact version in a module.
+- AWS: `>= 6` (no upper bound).
+- AzureAD: `>= 3, < 4`. Azurerm: `>= 4, < 5`. Datadog: `>= 3, < 4`. Upper bound at the next major.
 - Every provider block lists `source` explicitly, even for hashicorp providers.
 
 ---
@@ -187,7 +188,7 @@ Inside a `resource` block, arrange arguments in this order:
 3. Core configuration arguments (type, tier, size, encryption, …)
 4. Feature-flag arguments (booleans toggling optional behaviour)
 5. Nested blocks
-6. `tags = local.tags` (always last before the closing brace)
+6. `tags = var.tags` (always last before the closing brace)
 7. `lifecycle { … }` / `depends_on = [...]` (meta-blocks last)
 
 ```hcl
@@ -196,7 +197,7 @@ resource "aws_s3_bucket" "default" {
   bucket_prefix       = var.name_prefix
   force_destroy       = var.force_destroy
   object_lock_enabled = var.object_lock_mode != null
-  tags                = local.tags
+  tags                = var.tags
 }
 ```
 
@@ -255,23 +256,17 @@ output "arn" {
 ## 5. Tags (AWS / Azure)
 
 ```hcl
-# locals.tf
-locals {
-  tags = merge(var.tags, { ManagedBy = "Terraform" })
-}
-
-# main.tf
 resource "aws_s3_bucket" "default" {
   ...
-  tags = local.tags
+  tags = var.tags
 }
 ```
 
 **Rules:**
 
-- Expose `variable "tags"` with `type = map(string)` and `default = {}`. **67%** of modules do this; it should be universal.
-- Only **26%** currently merge via `locals.tags`. That is the right pattern — it lets the module add mandatory tags (`ManagedBy`, `Module`, etc.) without clobbering caller tags. Adopt it in new code.
-- Do not hard-code tag keys inside individual resources — always reference `local.tags`.
+- Expose `variable "tags"` with `type = map(string)` and `default = {}`. This should be universal.
+- Every taggable resource references `var.tags`. No `try(var.tags)` cargo-cult. No `local.tags` indirection unless the module genuinely needs to inject extra tags.
+- Do not hard-code tag keys inside individual resources.
 
 ---
 
@@ -363,47 +358,7 @@ run "default" {
 
 ## 9. Pre-commit
 
-92% of modules ship this exact `.pre-commit-config.yaml`:
-
-```yaml
-default_stages: [pre-commit]
-repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
-    hooks:
-      - id: check-json
-      - id: check-merge-conflict
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-yaml
-      - id: check-added-large-files
-      - id: pretty-format-json
-        args: [--autofix]
-      - id: detect-aws-credentials
-        args: [--allow-missing-credentials]
-      - id: detect-private-key
-  - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.98.1
-    hooks:
-      - id: terraform_fmt
-      - id: terraform_tflint
-      - id: terraform_docs
-      - id: terraform_validate
-  - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 3.2.388
-    hooks:
-      - id: checkov
-        verbose: false
-        args:
-          - --download-external-modules
-          - "true"
-          - --quiet
-          - --compact
-          - --skip-check
-          - CKV_GIT_5,CKV_GLB_1,CKV_TF_1
-          - --skip-path
-          - examples/*
-```
+The canonical config is maintained in [`mcaf-github-workflows/sync-root/.pre-commit-config.yaml`](https://github.com/schubergphilis/mcaf-github-workflows/blob/main/sync-root/.pre-commit-config.yaml). Read the repository's copy for exact hooks and versions. Do not hardcode or duplicate the config here.
 
 **Skipped checkov checks (by policy):**
 
@@ -638,7 +593,7 @@ Use `terraform-aws-mcaf-s3` as the reference implementation for AWS and `terrafo
 Ten things that the structural checklist does not catch but which appear across the corpus. Use this list as the qualitative checklist when reviewing a module.
 
 1. **Whole-resource outputs that leak state** — `output "resource" { value = aws_kubernetes_cluster.this }` re-exports every attribute including sensitive ones (`kube_admin_config`, `admin_password`). Always expose a curated set of named outputs. Mark any credential/token output `sensitive = true`.
-2. **`try(var.tags)` cargo-culted** — `var.tags` defaults to `{}`; a `try()` around it is noise, and worse, masks real type errors. Drop it and use the `local.tags` merge from §5.
+2. **`try(var.tags)` cargo-culted** — `var.tags` defaults to `{}`; a `try()` around it is noise, and worse, masks real type errors. Drop it and use `var.tags` directly (§5).
 3. **Two sources of truth for resource group** — Azure modules that take both `var.resource_group_name` AND `var.<obj>.resource_group_name` and `count`-toggle an internal `azurerm_resource_group.this`. Standardise on caller-owned RG; never create one inside a reusable module.
 4. **Hard-pinned child-module refs** — `source = "github.com/schubergphilis/...?ref=vX.Y.Z"` inside a module propagates that version to every consumer. Use registry semver ranges (`schubergphilis/<name>/<provider>` + `version = "~> X.Y"`) instead.
 5. **Missing `outputs.tf` entirely** — several modules ship no outputs and become black boxes. Every module producing a resource MUST expose at least `id`/`arn`/`name` (§4).
@@ -664,5 +619,5 @@ Bug classes worth explicit spot-checks during review (observed in the corpus at 
 Clone the structure of these when starting something new:
 
 - **AWS**: `terraform-aws-mcaf-s3` (full-surface), `terraform-aws-mcaf-kms` (thin wrapper).
-- **Azure**: `terraform-azure-mcaf-storage-account` (full-surface), `terraform-azure-mcaf-container-app-environment` (one of the few with correct `local.tags` pattern + native tests).
+- **Azure**: `terraform-azure-mcaf-storage-account` (full-surface), `terraform-azure-mcaf-container-app-environment` (correct `var.tags` usage + native tests).
 - **GitHub/TFE/GitLab**: `terraform-github-mcaf-repository` (the highest-quality module in the corpus).

--- a/skills/mcaf-module/GUIDE.md
+++ b/skills/mcaf-module/GUIDE.md
@@ -181,15 +181,13 @@ Then downstream outputs that expose IDs/ARNs other modules reference (VPC IDs, s
 
 ### Resource argument ordering
 
-Inside a `resource` block, arrange arguments in this order:
+Inside a `resource` block, arrange arguments in this order. Empty lines separate each group:
 
-1. `provider = …` / `for_each = …` / `count = …` (meta-args first when present)
-2. Identifying arguments — whatever the provider uses as the primary identity (`name`, `bucket`, `bucket_prefix`, `resource_group_name`, `location`)
-3. Core configuration arguments (type, tier, size, encryption, …)
-4. Feature-flag arguments (booleans toggling optional behaviour)
-5. Nested blocks
-6. `tags = var.tags` (always last before the closing brace)
-7. `lifecycle { … }` / `depends_on = [...]` (meta-blocks last)
+1. `count` / `for_each` — meta-args first; even when written as a block, keep on top.
+2. `provider`.
+3. `region`, identifier (`name`, `role`, `bucket`, `resource_group_name`, …), then **alphabetically sorted** other fields, then `tags`.
+4. Nested blocks (each separated by empty lines).
+5. Meta-argument blocks: `depends_on`, `lifecycle`.
 
 ```hcl
 resource "aws_s3_bucket" "default" {
@@ -200,6 +198,17 @@ resource "aws_s3_bucket" "default" {
   tags                = var.tags
 }
 ```
+
+### Module argument ordering
+
+Inside a `module` block, arrange arguments in this order. Empty lines separate each group:
+
+1. `count` / `for_each`.
+2. `source`, `version`.
+3. `providers`.
+4. `region`, identifier (`name`, …), then **alphabetically sorted** other fields, then `tags`.
+5. Nested blocks (each separated by empty lines).
+6. Meta-argument blocks: `depends_on`, `lifecycle`.
 
 ### README section order
 

--- a/skills/mcaf-module/GUIDE.md
+++ b/skills/mcaf-module/GUIDE.md
@@ -1,0 +1,668 @@
+# MCAF Terraform Module — Way of Working
+
+Synthesised from **91 active `schubergphilis/terraform-*-mcaf-*` public modules** (47 AWS, 39 Azure, 2 TFE, 1 GitHub, 1 GitLab, 1 Datadog). Each rule lists the adoption rate seen in the corpus so the "defaults" are grounded in what the codebase actually does, not aspiration.
+
+This document is the reference humans read when starting, maintaining, or reviewing an MCAF module. It is also the authority that three skills cite:
+
+- `.claude/skills/terraform/` — generic Terraform / OpenTofu baseline (module patterns, testing, CI/CD, security). MCAF is layered on top.
+- `.claude/skills/mcaf-module/` — MCAF deltas over the generic skill; structural authoring and PR review.
+- `.claude/skills/review-mcaf/` — full qualitative review (best practices, usability, LCM, supply chain, security).
+
+Rules below carry the adoption rate seen in the corpus so "default" reflects what MCAF actually does, not aspiration.
+
+---
+
+## 1. Repository layout
+
+```
+<root>/
+├── main.tf                    # (86%) primary resources
+├── variables.tf               # (94%) every variable, with description + type
+├── variables.<topic>.tf       # split by domain when the module is large (seen in azure storage-account, core)
+├── outputs.tf                 # (82%) every output, with description
+├── terraform.tf               # (82%) REQUIRED file name — holds required_version + required_providers
+├── locals.tf                  # (24%) only when locals actually exist
+├── data.tf                    # (8%)  only when data sources exist
+├── examples/                  # (90%) one subdir per scenario — at minimum a "default" example
+│   └── default/
+├── tests/                     # (17% but growing) native terraform test harness
+│   ├── main.tftest.hcl
+│   └── setup/                 # optional fixture module invoked via `run "setup"`
+├── modules/                   # (17%) only for multi-module repos (landing-zone, account-baseline …)
+├── .github/workflows/         # (97%) copied verbatim from mcaf-github-workflows
+├── .pre-commit-config.yaml    # (92%)
+├── Taskfile.yaml              # (26% combined .yaml/.yml, now the default for new modules)
+├── README.md                  # (96%) prose + auto-injected terraform-docs block
+├── CHANGELOG.md               # (75%) maintained by release-drafter
+├── CONTRIBUTING.md            # (85%) boilerplate about conventional commits + pre-commit
+├── UPGRADING.md               # (35%) required if there are breaking changes
+└── LICENSE                    # (96%) Apache 2.0
+```
+
+**Rules:**
+
+- Use `terraform.tf` **not** `versions.tf`. 81% of modules already use `terraform.tf`; the 10% on `versions.tf` are the older/less-maintained set. New modules and any module being touched MUST use `terraform.tf`.
+- Use `providers.tf` for provider *configuration* blocks **only when a module needs aliased providers**. 99% of modules omit it because provider config belongs in the root caller, not inside a reusable module.
+- Do not create empty files. No `locals.tf` if you have no locals.
+- For multi-resource modules with >~40 variables, split `variables.tf` by domain: `variables.networking.tf`, `variables.share.tf`, etc. Keep `variables.tf` for the core set.
+
+---
+
+## 2. `terraform.tf` — version pinning
+
+```hcl
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0, < 7.0"
+    }
+  }
+}
+```
+
+**Rules:**
+
+- `required_version` — set a **minimum** with `>=`, no upper bound on Terraform itself. The current MCAF floor is **`>= 1.9`** (37% of modules; growing). Anything below `>= 1.7` is legacy and should be bumped next touch.
+- Provider `version` — express both floor and ceiling as **`>= X.Y, < (X+1).0`**. Pinning only with `~>` is accepted but less common. Do NOT pin to an exact version in a module.
+- AWS provider floor is **`>= 6.0`** (adoption: 19/47 AWS modules already on 6.x, another 13 on 5.x with stated intent to bump).
+- Azure provider floor is **`>= 4.0`** (adoption: 18/39 Azure modules).
+- Datadog provider floor is **`>= 3.39`**.
+- Every provider block lists `source` explicitly, even for hashicorp providers.
+
+---
+
+## 3. Variables
+
+```hcl
+variable "name" {
+  type        = string
+  description = "The name of the bucket. If omitted, Terraform will assign a random unique name. Conflicts with `name_prefix`."
+  default     = null
+}
+
+variable "object_lock_mode" {
+  type        = string
+  default     = null
+  description = "The default object Lock retention mode to apply to new objects."
+  nullable    = true
+
+  validation {
+    condition     = var.object_lock_mode == null || contains(["GOVERNANCE", "COMPLIANCE"], coalesce(var.object_lock_mode, "GOVERNANCE"))
+    error_message = "object_lock_mode must be one of GOVERNANCE or COMPLIANCE."
+  }
+}
+```
+
+**Rules:**
+
+- **Every** variable has a `description`. No exceptions.
+- **Every** variable has an explicit `type`.
+- Order of arguments inside the block: `type`, `default`, `description`, `sensitive`, `nullable`, `validation`. This is the order seen in ~80% of recently-touched modules.
+- Prefer **complex typed objects** with `optional(..., <default>)` over dozens of flat variables. S3 / Aurora / Fargate modules are good examples — their nested `object({ ... })` signatures let callers stay terse.
+- Use `validation` blocks for anything with an enumerated set of valid values, regex constraints, or cross-field invariants. 54% of modules already have at least one validation; aim for 100% on new variables with non-obvious constraints.
+- Use `sensitive = true` on secrets, tokens, passwords. Never default a sensitive variable to a real value.
+- Use `nullable = false` when `null` is genuinely not a valid value for the caller. 23% of modules use this today — under-used, because `null` often sneaks through as a silent default.
+- Use `default = null` (not `default = ""`) to express "not provided". This lets `null`-aware conditionals like `var.x == null ? ... : ...` work cleanly.
+- Naming: `snake_case`, descriptive, not abbreviated. Boolean flags read as statements: `versioning` (not `enable_versioning`), `force_destroy`, `bucket_key_encryption_enforced`.
+
+---
+
+## 3.5 Style & naming conventions
+
+The style rules below are extracted from what the corpus actually does, not from HashiCorp's generic style guide. They're the ones CI doesn't enforce but reviewers should.
+
+### Resource/data/module label convention
+
+Each provider family has ONE canonical single-resource label:
+
+| Provider | Convention | Evidence |
+|---|---|---|
+| `aws`, `github`, `datadog`, `tfe`, `gitlab` | `"default"` | 217 occurrences, 0 outside this set |
+| `azure` | `"this"` | 114 occurrences, 0 `"default"` |
+
+```hcl
+# AWS — use "default"
+resource "aws_s3_bucket" "default" { ... }
+data   "aws_caller_identity" "default" {}
+
+# Azure — use "this"
+resource "azurerm_storage_account" "this" { ... }
+data     "azurerm_client_config" "current" {}   # exception: data for caller identity uses "current"
+```
+
+- For additional instances of the same resource type, use a descriptive label (`"logging"`, `"replica"`, `"cmk"`) — not `"default2"` or `"this_extra"`.
+- For resources created via `for_each`/`count`, the single canonical label still applies (`for_each` is what expresses multiplicity).
+
+### Variable block internal order
+
+```hcl
+variable "x" {
+  type        = …       # 1. type first
+  default     = …       # 2. default (if present)
+  description = "…"     # 3. description (always)
+  nullable    = false   # 4. nullable (if non-default)
+  sensitive   = true    # 5. sensitive (if non-default)
+  validation { … }      # 6. validation blocks last
+}
+```
+
+This is the order in `terraform-aws-mcaf-s3` and every reference module. Respect it.
+
+### Variable source-file ordering
+
+The corpus is split: older modules are alphabetical, newer ones group related variables. **Either is acceptable**, because CI renders the README with `terraform-docs --sort-by required`, so the user-facing order is normalised regardless.
+
+- If you choose **alphabetical**, keep it strict (the `terraform_docs` pre-commit hook will reorder on drift).
+- If you choose **logical grouping**, put identifying variables first (`name`, `resource_group_name`/`region`, `location`), then related feature clusters, then the catch-all `tags` at the end.
+- For very large modules (>40 variables), split `variables.tf` into `variables.<domain>.tf` and apply ordering within each file.
+
+### Output ordering
+
+Outputs should be ordered by **usefulness to the caller**, not alphabetically. The canonical head of `outputs.tf` for any resource module is:
+
+```hcl
+output "id"   { … }  # or "name" for Azure (which mostly uses name as ID)
+output "arn"  { … }  # AWS only
+output "name" { … }
+```
+
+Then downstream outputs that expose IDs/ARNs other modules reference (VPC IDs, subnet IDs, role ARNs, etc.).
+
+### Naming
+
+- All identifiers (variables, outputs, locals, resource labels) are `snake_case`. No camelCase, no kebab-case. No exceptions.
+- Boolean variables read as declarative statements about the desired state: `versioning`, `force_destroy`, `bucket_key_encryption_enforced`. Avoid `enable_` / `disable_` prefixes when the variable name already implies a state.
+- Avoid redundant prefixes that repeat the module's purpose. In `terraform-aws-mcaf-s3`, the variable is `versioning`, not `s3_versioning`; the output is `arn`, not `bucket_arn`.
+- Module names in `module "foo"` blocks follow the same snake_case rule and should describe what the module *is*, not what it is *for* (`module "logging_bucket"`, not `module "create_logging"`).
+
+### Resource argument ordering
+
+Inside a `resource` block, arrange arguments in this order:
+
+1. `provider = …` / `for_each = …` / `count = …` (meta-args first when present)
+2. Identifying arguments — whatever the provider uses as the primary identity (`name`, `bucket`, `bucket_prefix`, `resource_group_name`, `location`)
+3. Core configuration arguments (type, tier, size, encryption, …)
+4. Feature-flag arguments (booleans toggling optional behaviour)
+5. Nested blocks
+6. `tags = local.tags` (always last before the closing brace)
+7. `lifecycle { … }` / `depends_on = [...]` (meta-blocks last)
+
+```hcl
+resource "aws_s3_bucket" "default" {
+  bucket              = var.name
+  bucket_prefix       = var.name_prefix
+  force_destroy       = var.force_destroy
+  object_lock_enabled = var.object_lock_mode != null
+  tags                = local.tags
+}
+```
+
+### README section order
+
+The `terraform-docs` template in use (see `.terraform-docs.yml`) fixes this order between the markers:
+
+```
+Requirements → Providers → Modules → Resources → Inputs → Outputs
+```
+
+Do not introduce new headings inside the `<!-- BEGIN_TF_DOCS --> / <!-- END_TF_DOCS -->` block — it will be overwritten. Prose feature sections go **above** the block; `## Licensing` goes **below** it.
+
+### File section ordering inside `main.tf`
+
+When a module keeps data/locals/resources all in `main.tf` (i.e. doesn't split into `data.tf` / `locals.tf`), the internal order is:
+
+1. `data "…" "default"` blocks (AWS) / `data "…" "current"` (Azure)
+2. `locals { … }` block
+3. `module "…"` blocks (dependency parents first)
+4. `resource "…"` blocks, with the primary resource first, then supporting resources in dependency order
+
+### Terraform-docs specifics
+
+- CI runs `terraform-docs` with `--sort-by required` (so required inputs render above optional ones).
+- A checked-in `.terraform-docs.yml` is optional — only 2/91 modules ship one. Ship it when you need per-repo deviation (e.g. recursive docs for `modules/`), otherwise rely on the default template baked into the `terraform-docs/gh-actions` step.
+
+### Anti-patterns
+
+- `resource "aws_s3_bucket" "bucket"` — redundant, use `"default"`.
+- `resource "azurerm_storage_account" "default"` — Azure convention is `"this"`.
+- Variable block with `description` on top, then `type`, then `default` — reverse the order.
+- `enable_versioning = bool` — rename to `versioning`.
+- Alphabetised outputs where `arn`/`id`/`name` aren't first.
+- Sorting variables alphabetically *and* adding `# Core` / `# Networking` comment headers — pick one system.
+
+---
+
+## 4. Outputs
+
+```hcl
+output "arn" {
+  description = "ARN of the bucket"
+  value       = aws_s3_bucket.default.arn
+}
+```
+
+**Rules:**
+
+- Every output has a `description` and a `value`.
+- Expose the minimum useful surface: `id`, `arn`, `name`, and any ID your callers need to reference from other modules. Do not re-export every attribute of every resource.
+- Mark sensitive outputs with `sensitive = true`.
+
+---
+
+## 5. Tags (AWS / Azure)
+
+```hcl
+# locals.tf
+locals {
+  tags = merge(var.tags, { ManagedBy = "Terraform" })
+}
+
+# main.tf
+resource "aws_s3_bucket" "default" {
+  ...
+  tags = local.tags
+}
+```
+
+**Rules:**
+
+- Expose `variable "tags"` with `type = map(string)` and `default = {}`. **67%** of modules do this; it should be universal.
+- Only **26%** currently merge via `locals.tags`. That is the right pattern — it lets the module add mandatory tags (`ManagedBy`, `Module`, etc.) without clobbering caller tags. Adopt it in new code.
+- Do not hard-code tag keys inside individual resources — always reference `local.tags`.
+
+---
+
+## 6. Examples
+
+**Rules:**
+
+- `examples/` is required (90% have it). Every module MUST have at least `examples/default/` that exercises sensible defaults.
+- Add one example per major scenario (encrypted, replication, public, private-endpoint, …).
+- Examples **do not pin module versions** — they reference `source = "../../"` or `source = "schubergphilis/<name>/<provider>"` without a `version =`. Recommend pinning in the README's `IMPORTANT` banner only.
+- Examples are the surface that `terraform-validation.yaml` lints/validates in CI, so every example must be runnable with `terraform init && terraform validate`.
+
+---
+
+## 7. Tests — native `terraform test`
+
+The corpus has **zero terratest** (historical — was dropped) and **17%** native `terraform test` adoption, growing fast. Native tests are the MCAF standard.
+
+```
+tests/
+├── main.tftest.hcl
+└── setup/
+    └── main.tf     # optional fixture resources the test depends on
+```
+
+```hcl
+# tests/main.tftest.hcl
+mock_provider "aws" {
+  mock_data "aws_region" {
+    defaults = { region = "eu-central-1" }
+  }
+}
+
+run "setup" {
+  module {
+    source = "./tests/setup"
+  }
+}
+
+run "default" {
+  command = plan
+  module  { source = "./" }
+
+  assert {
+    condition     = aws_s3_bucket.default.region == "eu-central-1"
+    error_message = "Expected region eu-central-1, got: ${aws_s3_bucket.default.region}"
+  }
+}
+```
+
+**Rules:**
+
+- Use `mock_provider` so tests run without AWS/Azure credentials. This is how modules get validated in PR CI.
+- First `run` is `setup` (fixtures). Then one `run` per behaviour branch: `default`, `with_logging`, `with_kms`, `invalid_input`, etc.
+- For invalid-input paths, use `expect_failures = [var.foo]` to assert the validation fires.
+- Do not assert on raw resource fields that are identical to the input variable — test *derived* values and *conditional* resources.
+- Tests MUST live under `tests/` (no `test/`, no `terratest/`).
+
+---
+
+## 8. CI — `mcaf-github-workflows`
+
+85% of modules reuse the shared workflows from `schubergphilis/mcaf-github-workflows`. The files under `.github/workflows/` are **copied verbatim** and carry the header:
+
+```yaml
+# DO NOT CHANGE THIS FILE DIRECTLY
+# Source: https://github.com/schubergphilis/mcaf-github-workflows
+```
+
+**Standard workflow set (each ≥85% adoption):**
+
+| File | Purpose |
+|---|---|
+| `pr-validation.yaml` | PR title lint (conventional commits), PR label check, release-drafter autolabeler. |
+| `terraform-validation.yaml` | `terraform fmt -check -recursive`, `tflint` on root + every example, `terraform validate` per example, `terraform test` (unless `SKIP_TERRAFORM_TESTS` var set), terraform-docs injection into README, checkov scan. |
+| `label-synchronization.yaml` | Keeps repo labels in sync with the standard set. |
+| `release-drafter.yaml` | Maintains draft release notes based on merged PR titles/labels. |
+| `update-changelog.yaml` | Writes CHANGELOG.md on publish. |
+| `terraform-test.yaml` | (16 modules so far) Runs `task test` via Taskfile — new-style test runner, complementing the one baked into `terraform-validation.yaml`. |
+
+**Rules:**
+
+- Do not modify these workflow files. If you need different behaviour, propose the change upstream in `mcaf-github-workflows`.
+- Do not add ad-hoc workflows. Lambda-specific modules may add one targeted workflow (seen with `build-lambda.yml`), but the core five above remain.
+- Required repo labels (enforced by `label-checker` job): `breaking`, `bug`, `chore`, `documentation`, `enhancement`, `feature`, `fix`, `security`. At least one must be on the PR.
+- PR titles MUST follow **conventional commits**. Allowed types: `breaking`, `bug`, `chore`, `docs`, `documentation`, `enhancement`, `feat`, `feature`, `fix`, `security`.
+
+---
+
+## 9. Pre-commit
+
+92% of modules ship this exact `.pre-commit-config.yaml`:
+
+```yaml
+default_stages: [pre-commit]
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-json
+      - id: check-merge-conflict
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: pretty-format-json
+        args: [--autofix]
+      - id: detect-aws-credentials
+        args: [--allow-missing-credentials]
+      - id: detect-private-key
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.98.1
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_tflint
+      - id: terraform_docs
+      - id: terraform_validate
+  - repo: https://github.com/bridgecrewio/checkov.git
+    rev: 3.2.388
+    hooks:
+      - id: checkov
+        verbose: false
+        args:
+          - --download-external-modules
+          - "true"
+          - --quiet
+          - --compact
+          - --skip-check
+          - CKV_GIT_5,CKV_GLB_1,CKV_TF_1
+          - --skip-path
+          - examples/*
+```
+
+**Skipped checkov checks (by policy):**
+
+- `CKV_GIT_5` / `CKV_GLB_1` — "≥2 approving reviews". MCAF policy is "≥1 approval".
+- `CKV_TF_1` — "module sources must use commit hash". MCAF uses semantic versioning.
+
+---
+
+## 10. Taskfile
+
+New-style modules ship a `Taskfile.yaml`:
+
+```yaml
+version: "3"
+env: { TF_IN_AUTOMATION: 1 }
+tasks:
+  default:
+    cmds: [{ cmd: "task --list", ignore_error: true }]
+    silent: true
+  clean:
+    desc: Clean lock files and cache directories
+    cmds:
+      - rm -rf .terraform.lock.hcl .terraform
+      - rm -rf **/.terraform.lock.hcl **/.terraform
+    silent: true
+  test:
+    desc: Run Terraform tests
+    cmds: ["terraform init", "terraform test"]
+    silent: true
+  verbose-test:
+    desc: Run verbose Terraform tests
+    cmds: ["terraform init", "terraform test -verbose"]
+    silent: true
+```
+
+**Rules:**
+
+- Prefer `Taskfile.yaml` (not `.yml`). The emerging standard.
+- At minimum expose `default`, `clean`, `test`, `verbose-test`.
+- CI's `terraform-test.yaml` calls `task test`, so Taskfile and CI stay in lockstep.
+
+---
+
+## 11. README
+
+```markdown
+# terraform-aws-mcaf-<name>
+
+<One-line purpose.>
+
+IMPORTANT: We do not pin modules to versions in our examples. We highly recommend that in your code you pin the version to the exact version you are using so that your infrastructure remains stable.
+
+## <Feature section(s) — prose about non-obvious behaviour>
+
+<!-- BEGIN_TF_DOCS -->
+<!-- auto-injected by terraform-docs via the CI workflow; DO NOT EDIT -->
+<!-- END_TF_DOCS -->
+
+## Licensing
+
+100% Open Source and licensed under the Apache License Version 2.0. See [LICENSE](...) for full details.
+```
+
+**Rules:**
+
+- First H1 = repo name. First paragraph = one-line purpose.
+- The version-pinning `IMPORTANT` banner is mandatory.
+- Add prose sections for anything a reader cannot infer from the auto-generated inputs table (e.g. gotchas, AWS-specific caveats, lifecycle warnings, compatibility notes).
+- The `BEGIN_TF_DOCS` / `END_TF_DOCS` markers are required (86% of modules have them). CI injects inputs/outputs/resources.
+- End with a `## Licensing` section pointing at the LICENSE file.
+- Do not add a `## Usage` section with hand-written HCL snippets — point people to `examples/` instead. (Only 15% have a Usage section; it rots.)
+
+---
+
+## 12. Release flow
+
+- `release-drafter` maintains a draft release based on merged PR labels. Label → section mapping is defined in `release-drafter-config.yaml` (comes from `mcaf-github-workflows`).
+- Version bump rules (driven by labels on merged PRs):
+  - `breaking` → **major**
+  - `feature`, `enhancement` → **minor**
+  - `fix`, `bug`, `security`, `documentation`, `chore` → **patch**
+- `no-changelog` on a PR excludes it from the draft.
+- Only `MCAF Contributors` publish releases (click pencil on draft → Update release).
+- If the release contains breaking changes, an `UPGRADING.md` entry is mandatory. 35% of modules have one; anything that ever broke should.
+
+---
+
+## 12.5 Lifecycle / currency targets
+
+Modules drift behind Terraform, provider, and action releases. The targets below are the currency bar; anything older is technical debt to close on next touch. The `review-mcaf` skill flags LCM findings per module.
+
+| Dependency | Current (2026-04) | MCAF minimum | Pinning style in module |
+|---|---|---|---|
+| Terraform | `1.14` | no upper bound (must allow newest) | `required_version = ">= 1.9"` (floor only) |
+| `hashicorp/aws` | `6.x` | major `6` | `">= 6.0, < 7.0"` or `"~> 6.0"` |
+| `hashicorp/azurerm` | `4.x` | major `4` | `">= 4, < 5.0"` |
+| `hashicorp/azuread` | `3.x` | major `3` | `">= 3, < 4.0"` |
+| `datadog/datadog` | `3.x` | major `3` | `">= 3.39, < 4.0"` |
+| `integrations/github` | `6.x` | major `6` | `">= 6.0, < 7.0"` |
+| `okta/okta` | `5.x` | major `5` | `">= 5.0, < 6.0"` |
+| `hashicorp/tls` | `4.x` | major `4` | `">= 4.0, < 5.0"` |
+| `hashicorp/random` | `3.x` | major `3` | `">= 3.0, < 4.0"` |
+| `hashicorp/null` | `3.x` | major `3` | `">= 3.0, < 4.0"` |
+| `hashicorp/http` | `3.x` | major `3` | `">= 3.0, < 4.0"` |
+| `hashicorp/archive` | `2.x` | major `2` | `">= 2.0, < 3.0"` |
+| `hashicorp/time` | `0.x` | major `0` | `">= 0.9, < 1.0"` |
+| `hashicorp/tfe` | `0.x` | major `0` | `">= 0.50, < 1.0"` |
+
+### Rules
+
+- **Never hard-pin providers in a module.** `version = "= 6.1.2"` forbids the caller from bumping — it propagates module debt outward.
+- **Avoid patch-tight pins** (`~> 6.1.2`). Pinning to the patch level (vs minor) blocks routine security patches and is almost never what the module author actually wanted. 3 modules in the corpus have this; all azure.
+- **Avoid pre-1.3 Terraform floors**. `>= 0.13` / `>= 1.0.0` cuts off `terraform test` (1.6+) and optional-attrs-with-defaults (1.3+). 5 modules in the corpus are still pre-1.3.
+- **No `required_version` missing** — 7 modules in the corpus are unset. The `terraform-validation` workflow cannot reason about version compatibility without it.
+
+### Deprecated patterns to remove on next touch
+
+- `resource "aws_s3_bucket_object"` → `aws_s3_object` (corpus: 0 left).
+- Inline `versioning`/`server_side_encryption_configuration`/`lifecycle_rule` blocks inside `aws_s3_bucket` (removed in aws v4) → separate resources (corpus: 0 left).
+- `resource "null_resource"` → `terraform_data` (Terraform ≥ 1.4). Corpus: 0 (already clean).
+- `list("a","b")` / `map("k","v")` constructor calls → `["a","b"]` / `{k="v"}` literals (corpus: 0 left).
+
+### Outdated workflow action pins (corpus hotspots)
+
+- `hashicorp/setup-terraform@v2` → `@v3` (23 modules).
+- `actions/checkout@master` / `@v2` / `@v3` → `@v4` (≥8 modules).
+- `actions/github-script@v6` → `@v7`.
+- `terraform-docs/gh-actions@v1.1.0` / `@v1.2.0` → `@v1.3.0`.
+- Legacy security scanners (`aquasecurity/tfsec`, `triat/terraform-security-scan`) → replaced by the `bridgecrewio/checkov-action@v12` step that already exists in `terraform-validation.yaml`.
+- Legacy label-checker (`danielchabr/pr-labels-checker`) → replaced by `docker://agilepathway/pull-request-label-checker` in mcaf-github-workflows.
+
+Fixing these is not per-module work — it's upstream work in `mcaf-github-workflows`, which then flows out via the `DO NOT CHANGE` sync. **If a module still has v2 action pins, it has drifted from the shared workflows — re-sync it first.**
+
+---
+
+## 12.6 Supply chain
+
+Terraform modules execute CI workflows and, in a few cases, bundle Lambda source. That gives two concrete supply-chain surfaces: **GitHub Actions** and **Lambda dependency manifests**. The `review-mcaf` skill flags supply-chain findings per module.
+
+### GitHub Actions — pinning & trust
+
+**Pin types, ordered safest-first:**
+
+1. **SHA** (`uses: org/repo@<40-char-hex>`) — immutable. Recommended for any action not in MCAF's trusted set.
+2. **Exact tag** (`@v1.3.0`) — immutable in practice; a retag would be noticed.
+3. **Minor tag** (`@v1.3`) — floating, patch bumps silently; acceptable for trusted publishers.
+4. **Major tag** (`@v3`) — floating across minors; acceptable for trusted publishers, not for others.
+5. **Branch** (`@master`, `@main`) — **never**. Allows arbitrary code injection via a push to that branch.
+
+Corpus today: **1 SHA-pinned**, 7 exact-tag, 1 minor-tag, 23 major-tag, **3 branch-pinned** (from 3 old modules).
+
+**Trusted publishers** — major-tag is acceptable:
+
+`actions`, `github`, `hashicorp`, `terraform-docs`, `terraform-linters`, `bridgecrewio`, `arduino`, `release-drafter`, `amannn`, `marocchino`, `agilepathway`, `crazy-max`, `stefanzweifel`.
+
+**Flagged publishers** — remove from any MCAF module workflow on next touch:
+
+- `Dirrk/terraform-docs` — abandoned fork; use `terraform-docs/gh-actions@v1.3.0`.
+- `triat/terraform-security-scan` — unmaintained; the checkov step already scans.
+- `danielchabr/pr-labels-checker` — non-standard; `mcaf-github-workflows` uses `agilepathway/pull-request-label-checker`.
+- `anothrNick/github-tag-action` — one-person repo.
+- `jessfraz/*` — personal.
+
+**Docker image actions** (`uses: docker://org/image:tag`) should ideally pin by digest (`image@sha256:...`). The shared workflow pins `agilepathway/pull-request-label-checker:v1.6.55` by tag — fix upstream.
+
+### Lambda dependency manifests
+
+Only modules that bundle Lambda source have these:
+
+- Python: use `requirements.txt` with `==X.Y.Z` exact pins (corpus: all 5 Python manifests are compliant).
+- Node: use `package.json` + `package-lock.json` (committed). Caret/tilde ranges without a lockfile are not reproducible (corpus: 1 module — `cloudfront` auth lambda — fails this).
+
+### Supply-chain review — blocking findings
+
+The following are blocking findings in a PR review. No other supply-chain category stops a merge, but each of these must be addressed:
+
+- Any action using `@master` / `@main` (mutable branch ref).
+- Any action from a flagged publisher (see lists above).
+- Any Python package in a Lambda `requirements.txt` without `==X.Y.Z`.
+- Any `package.json` without a committed lockfile (`package-lock.json` / `yarn.lock` / `pnpm-lock.yaml`).
+- Any action from an untrusted publisher pinned by anything other than a 40-char SHA.
+
+---
+
+## 13. Secondary conventions worth adopting
+
+These are underused in the corpus but recommended for new/maintained modules:
+
+- **CODEOWNERS** — 0% adoption. Add one so PRs get auto-routed to the owning team.
+- **Renovate/Dependabot** config in repo — 0% adoption (managed centrally). If central management goes away, add `renovate.json` with the MCAF preset.
+- **`.tflint.hcl`** — 1% adoption. A root-level tflint config with the provider ruleset lets local `pre-commit` match CI exactly.
+- **Nullable/validation coverage** — raise the 54% validation coverage and 23% `nullable=false` coverage to 100% on new modules.
+
+---
+
+## 14. Module skeleton — copy/paste starting point
+
+```
+terraform-<provider>-mcaf-<name>/
+├── main.tf
+├── variables.tf
+├── outputs.tf
+├── terraform.tf
+├── README.md
+├── CHANGELOG.md
+├── CONTRIBUTING.md
+├── LICENSE
+├── Taskfile.yaml
+├── .pre-commit-config.yaml
+├── .github/workflows/
+│   ├── label-synchronization.yaml
+│   ├── pr-validation.yaml
+│   ├── release-drafter.yaml
+│   ├── terraform-test.yaml
+│   ├── terraform-validation.yaml
+│   └── update-changelog.yaml
+├── examples/
+│   └── default/
+│       └── main.tf
+└── tests/
+    ├── main.tftest.hcl
+    └── setup/
+        └── main.tf
+```
+
+Use `terraform-aws-mcaf-s3` as the reference implementation for AWS and `terraform-azure-mcaf-storage-account` for Azure.
+
+---
+
+## 15. Recurring anti-patterns
+
+Ten things that the structural checklist does not catch but which appear across the corpus. Use this list as the qualitative checklist when reviewing a module.
+
+1. **Whole-resource outputs that leak state** — `output "resource" { value = aws_kubernetes_cluster.this }` re-exports every attribute including sensitive ones (`kube_admin_config`, `admin_password`). Always expose a curated set of named outputs. Mark any credential/token output `sensitive = true`.
+2. **`try(var.tags)` cargo-culted** — `var.tags` defaults to `{}`; a `try()` around it is noise, and worse, masks real type errors. Drop it and use the `local.tags` merge from §5.
+3. **Two sources of truth for resource group** — Azure modules that take both `var.resource_group_name` AND `var.<obj>.resource_group_name` and `count`-toggle an internal `azurerm_resource_group.this`. Standardise on caller-owned RG; never create one inside a reusable module.
+4. **Hard-pinned child-module refs** — `source = "github.com/schubergphilis/...?ref=vX.Y.Z"` inside a module propagates that version to every consumer. Use registry semver ranges (`schubergphilis/<name>/<provider>` + `version = "~> X.Y"`) instead.
+5. **Missing `outputs.tf` entirely** — several modules ship no outputs and become black boxes. Every module producing a resource MUST expose at least `id`/`arn`/`name` (§4).
+6. **Missing `sensitive = true` on credentials** — master passwords, storage access keys, API keys, kubeconfig outputs. Mechanical to audit; consistently missed.
+7. **Floating `:latest` / `:main` image/version defaults** — makes the module silently non-idempotent and is a supply-chain risk. Default to a known-good version and document `"latest"` as opt-in.
+8. **Dead variables / locals / files** — declared but never read, or referenced after being removed. Delete on the next touch instead of renaming.
+9. **File-naming drift** — `functionApp.tf` / `storageAccount.tf` (camelCase), `Taskfile.yml` vs `Taskfile.yaml`, `backend.tf` / `module.tf` / `versions.tf` in place of the canonical names in §1. Fix before CI drifts further.
+10. **Deeply nested `ternary`/`coalesce` over `optional(..., default)`** — if a variable body is 80% `X != null ? X : default`, your type is wrong. Move defaults into the type with `optional(field, default)`.
+
+Bug classes worth explicit spot-checks during review (observed in the corpus at least once):
+
+- Swapped output wiring (VPC endpoint IDs wired to the wrong endpoint).
+- `each.value.*` vs `var.*` copy-paste bugs inside `for_each` blocks (node-pool scaling inheriting from system pool).
+- `aws_sqs_queue_policy`-style conditions using `.name` where `.arn` is required.
+- Relative paths in `archive_file.output_path` that write to the caller's CWD instead of `path.module`.
+- Modules broken at plan time because they reference a resource (`azurerm_resource_group.this`) that isn't defined anywhere.
+- Cron expressions with the wrong number of fields (AWS needs 7, Linux needs 5).
+
+---
+
+## Reference modules
+
+Clone the structure of these when starting something new:
+
+- **AWS**: `terraform-aws-mcaf-s3` (full-surface), `terraform-aws-mcaf-kms` (thin wrapper).
+- **Azure**: `terraform-azure-mcaf-storage-account` (full-surface), `terraform-azure-mcaf-container-app-environment` (one of the few with correct `local.tags` pattern + native tests).
+- **GitHub/TFE/GitLab**: `terraform-github-mcaf-repository` (the highest-quality module in the corpus).

--- a/skills/mcaf-module/SKILL.md
+++ b/skills/mcaf-module/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: mcaf-module
+description: Author or structurally review a Schuberg Philis MCAF Terraform module (`terraform-<provider>-mcaf-<name>`). Use when creating a new MCAF module, modifying an existing one, or reviewing a PR against one. This skill layers MCAF-specific rules on top of the generic `terraform` skill — start there for baseline guidance (module layout, variable/output design, testing, CI, security) and come here for the Schuberg Philis specifics (`terraform.tf` not `versions.tf`, reuse of `mcaf-github-workflows`, `local.tags` with `ManagedBy`, native `terraform test` with `mock_provider`, conventional-commit PR labels, release-drafter flow, and the recurring anti-patterns observed across the 91-module corpus). For a full qualitative review producing good/bad/verdict reports, use the `review-mcaf` skill instead.
+---
+
+# MCAF module
+
+MCAF-specific overlay on top of the generic [`terraform`](../terraform/SKILL.md) skill. Read that first for baseline Terraform/OpenTofu rules. This skill only documents the **deltas** — the things MCAF does that a generic module wouldn't.
+
+The authoritative source for every MCAF rule is [`GUIDE.md`](GUIDE.md) bundled with this skill.
+
+## When this skill applies
+
+- Creating a new repo named `terraform-<provider>-mcaf-<name>`.
+- Editing files in an existing MCAF module.
+- Reviewing a PR to an MCAF module for structural compliance.
+- User mentions "MCAF module", "mcaf-github-workflows", or a `schubergphilis/terraform-*-mcaf-*` repo.
+
+For a full **qualitative** review (good/bad, design critique, verdict), use `review-mcaf`.
+
+## Reference implementations
+
+- **AWS full-surface**: `terraform-aws-mcaf-s3`
+- **AWS thin wrapper**: `terraform-aws-mcaf-kms`
+- **Azure full-surface**: `terraform-azure-mcaf-storage-account`
+- **Azure with correct `local.tags` + native tests**: `terraform-azure-mcaf-container-app-environment`
+- **GitHub / GitLab / TFE reference**: `terraform-github-mcaf-repository`
+- **Shared CI**: `schubergphilis/mcaf-github-workflows`
+
+Diff against the reference for that provider when unsure.
+
+## MCAF deltas from the generic `terraform` skill
+
+These override or tighten the base skill. Everything not listed here defers to the generic skill.
+
+### Filenames
+
+- Use **`terraform.tf`** (not `versions.tf`) for `required_version` + `required_providers`.
+- Prefer `Taskfile.yaml` (lowercase `.yaml`).
+- No camelCase file names (`functionApp.tf` etc.).
+
+### Version pinning floors
+
+- Terraform: `required_version` must allow the newest Terraform (no upper bound). Any floor is acceptable.
+- AWS: `>= 6.0, < 7.0`. Azurerm: `>= 4, < 5.0`. AzureAD: `>= 3, < 4.0`. Datadog: `>= 3.39, < 4.0`.
+
+### Resource labels
+
+- AWS / GitHub / Datadog / TFE / GitLab → `"default"`.
+- Azure → `"this"`.
+- Never mix in one repo.
+
+### Tags
+
+Mandatory pattern, not optional:
+
+```hcl
+# locals.tf
+locals {
+  tags = merge(var.tags, { ManagedBy = "Terraform" })
+}
+```
+
+Every taggable resource references `local.tags`. No `try(var.tags)` cargo-cult.
+
+### CI via `mcaf-github-workflows`
+
+Five workflow files copied verbatim from `schubergphilis/mcaf-github-workflows`, with the `DO NOT CHANGE THIS FILE DIRECTLY` header intact:
+
+- `pr-validation.yaml`
+- `terraform-validation.yaml`
+- `label-synchronization.yaml`
+- `release-drafter.yaml`
+- `update-changelog.yaml`
+
+Plus `terraform-test.yaml` if using Taskfile-driven tests.
+
+Do not hand-edit these files. If you need different behaviour, change it upstream in `mcaf-github-workflows`.
+
+### PR requirements
+
+- Conventional-commit title with one of: `breaking`, `bug`, `chore`, `documentation`, `enhancement`, `feature`, `fix`, `security`.
+- At least one matching label.
+- Breaking change → entry in `UPGRADING.md`.
+
+### Pre-commit
+
+```yaml
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-json
+      - id: check-merge-conflict
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: pretty-format-json
+        args: [--autofix]
+      - id: detect-aws-credentials
+        args: [--allow-missing-credentials]
+      - id: detect-private-key
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.98.1
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_tflint
+      - id: terraform_docs
+      - id: terraform_validate
+  - repo: https://github.com/bridgecrewio/checkov.git
+    rev: 3.2.388
+    hooks:
+      - id: checkov
+        args:
+          - --download-external-modules
+          - "true"
+          - --quiet
+          - --compact
+          - --skip-check
+          - CKV_GIT_5,CKV_GLB_1,CKV_TF_1
+          - --skip-path
+          - examples/*
+```
+
+Skipped checkov rules (policy):
+
+- `CKV_GIT_5` / `CKV_GLB_1` — MCAF requires ≥1 approval, not ≥2.
+- `CKV_TF_1` — modules use semver tags, not commit SHAs.
+
+### Taskfile
+
+```yaml
+version: "3"
+env: { TF_IN_AUTOMATION: 1 }
+tasks:
+  default:
+    cmds: [{ cmd: "task --list", ignore_error: true }]
+    silent: true
+  clean:
+    cmds:
+      - rm -rf .terraform.lock.hcl .terraform
+      - rm -rf **/.terraform.lock.hcl **/.terraform
+    silent: true
+  test:
+    cmds: ["terraform init", "terraform test"]
+    silent: true
+  verbose-test:
+    cmds: ["terraform init", "terraform test -verbose"]
+    silent: true
+```
+
+### README structure
+
+```markdown
+# terraform-<provider>-mcaf-<name>
+
+<one-line purpose>
+
+IMPORTANT: We do not pin modules to versions in our examples. We highly recommend that in your code you pin the version to the exact version you are using so that your infrastructure remains stable.
+
+<prose sections for non-obvious behaviour>
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->
+
+## Licensing
+
+100% Open Source and licensed under the Apache License Version 2.0. See [LICENSE](LICENSE) for full details.
+```
+
+### Release flow
+
+- `release-drafter` maintains a draft release on every merge.
+- Version bump rules:
+  - `breaking` → major
+  - `feature` / `enhancement` → minor
+  - `fix` / `bug` / `security` / `documentation` / `chore` → patch
+- `no-changelog` label excludes a PR from release notes.
+- Only MCAF Contributors publish releases.
+
+## Lifecycle / currency (MCAF floors)
+
+Block new code adding instances of these:
+
+- Terraform `required_version` set and allows the newest Terraform (no upper bound). Any floor is acceptable.
+- AWS `>= 6`, Azurerm `>= 4`, AzureAD `>= 3`, Datadog `>= 3`.
+- No exact or patch-tight provider pins inside a module.
+- No deprecated AWS resources (`aws_s3_bucket_object`, inline `aws_s3_bucket` sub-blocks).
+- No deprecated HCL constructors (`list(...)`, `map(...)`).
+- Action pins up to date: `hashicorp/setup-terraform@v3`, `actions/checkout@v4`, `actions/github-script@v7`, `terraform-docs/gh-actions@v1.3.0`.
+
+If a module has older action pins, it has drifted from `mcaf-github-workflows` — re-sync the workflow files rather than hand-bumping.
+
+## Supply chain (MCAF-specific)
+
+Blocking findings for a PR review:
+
+- Any action using `@master` / `@main` — mutable ref.
+- Any action from `Dirrk`, `triat`, `danielchabr`, `anothrNick`, `jessfraz` — replace with the MCAF-standard equivalent.
+- Node `package.json` without a committed lockfile.
+- Python dependency in a Lambda `requirements.txt` without `==X.Y.Z`.
+- Docker image action pinned by mutable tag — prefer `@sha256:...`.
+
+**MCAF trusted publishers** (major-tag OK):
+`actions`, `github`, `hashicorp`, `terraform-docs`, `terraform-linters`, `bridgecrewio`, `arduino`, `release-drafter`, `amannn`, `marocchino`, `agilepathway`, `crazy-max`, `stefanzweifel`.
+
+Everything else → SHA pin or replace.
+
+## Recurring MCAF anti-patterns
+
+The generic `terraform` skill's anti-pattern list covers most cases. These are the MCAF-corpus-specific additions:
+
+1. **Two sources of truth for resource group on Azure** — `var.resource_group_name` AND `var.<obj>.resource_group_name` with a `count`-toggled internal `azurerm_resource_group.this`. The caller owns the RG, always.
+2. **Hard-pinned child-module refs** — `source = "github.com/schubergphilis/...?ref=vX.Y.Z"`. Use registry + `version = "~> X.Y"`.
+3. **Floating `:latest` / `:main` image defaults** — e.g. `ghcr.io/schubergphilis/<image>:main`. Pin to a known-good version and document `"latest"` as opt-in.
+4. **`try(var.tags)` around a var with a default** — cargo-cult that masks real errors.
+
+Bug classes spotted in the corpus worth explicit spot-checks:
+
+- Swapped output wiring (VPC endpoint IDs pointing at the wrong endpoint).
+- `each.value.*` vs `var.*` copy-paste inside `for_each` (user node pool inheriting system pool).
+- Policy conditions using `.name` where `.arn` is required.
+- `archive_file.output_path` as a relative path (writes to caller's CWD).
+- References to `azurerm_resource_group.this` that is never declared.
+- Cron expressions with the wrong number of fields.
+
+## Authoring workflow
+
+1. Create repo `terraform-<provider>-mcaf-<name>` in `schubergphilis`, default branch `main`.
+2. Copy skeleton from the reference for that provider (see list above). Don't copy lock files or state.
+3. Replace `.github/workflows/*` and `.pre-commit-config.yaml` with current versions from `mcaf-github-workflows` (preserve `DO NOT CHANGE` header).
+4. Write `terraform.tf` with a `required_version` that allows the newest Terraform (e.g. `">= 1.9"` — floor only, no upper bound) and provider ranges.
+5. Write `variables.tf` with types, descriptions, validations, `sensitive`/`nullable` as needed. Follow arg order rule.
+6. Write `main.tf`. Use `locals.tags = merge(var.tags, { ManagedBy = "Terraform" })`; reference `local.tags` on every taggable resource. Use canonical label (`"default"` or `"this"`).
+7. Write `outputs.tf`: `id` / `arn` / `name` first, each with `description`. No whole-resource dumps.
+8. Write `examples/default/main.tf` using `source = "../../"`, no `version =`.
+9. Add one example per major feature branch.
+10. Write `tests/main.tftest.hcl` with `mock_provider`, `run "setup"` if fixtures, `run "default"`, and a `run` per conditional path. `expect_failures` for negatives.
+11. Write `Taskfile.yaml` with `default`, `clean`, `test`, `verbose-test`.
+12. Write `README.md`; inject terraform-docs locally; CI regenerates on every PR.
+13. Standard `CONTRIBUTING.md`.
+14. `pre-commit run -a` until clean.
+15. Push. CI must go green on `terraform-validation` and `pr-validation`. Apply a label.
+16. On merge, `release-drafter` updates the draft release. Publish from the Releases page.
+
+## PR review workflow
+
+In order, fail fast:
+
+1. **PR hygiene** — conventional-commit title? label applied? `CHANGELOG.md` / `UPGRADING.md` updated?
+2. **File layout** — right locations? no `versions.tf` / `backend.tf` / `module.tf` / camelCase / `Makefile`?
+3. **`terraform.tf`** — provider bumps widen the upper bound? `required_version` not lowered?
+4. **Variables** — new var has `description` + `type`? enumerated values have `validation`? secrets `sensitive = true`? rename/retype triggers `breaking` label + `UPGRADING.md`? arg order inside block correct?
+5. **Outputs** — `description` present? no whole-resource leak? sensitive values marked?
+6. **Tags** — new taggable resource references `local.tags`? `try(var.tags)` removed if present?
+7. **Examples** — at least one exercises the change? still valid?
+8. **Tests** — new `run` block covers the new branch? `expect_failures` for negatives?
+9. **Workflows / pre-commit** — untouched? If edited: reject and point at `mcaf-github-workflows`.
+10. **LCM / supply-chain** — no new `@master` ref, no flagged publisher, no hard-pinned child module, provider floors still met.
+11. **Anti-patterns** — walk the corpus-specific list.
+12. **README** — prose sections accurate? (TF-docs block will be re-injected by CI.)
+
+## Common traps
+
+- Using `versions.tf` because some older module did — use `terraform.tf`.
+- Pinning providers with `version = "6.1.2"`. Use ranges.
+- Hand-written `## Usage` HCL snippets in the README — point to `examples/` instead.
+- Editing a `mcaf-github-workflows`-sourced file locally.
+- Mock provider omitted from tests — test tries to hit a real cloud.
+- Dumping every attribute into `outputs.tf`.
+- Mixed default representations: `""` vs `null`. Prefer `null`.
+- Merging `var.tags` directly at each resource.
+- Creating a resource group inside a module when caller should own it.
+- Forgetting to apply a PR label.
+
+## Useful one-liners
+
+```bash
+# Diff workflows against current mcaf-github-workflows
+gh api repos/schubergphilis/mcaf-github-workflows/contents/.github/workflow-templates | jq -r '.[].name'
+
+# Validate loop locally
+for d in examples/*/; do (cd "$d" && terraform init -backend=false && terraform validate); done
+
+# Mocked tests
+task test
+
+# Render the terraform-docs section
+terraform-docs . --sort-by required
+```
+
+## Related
+
+- [`terraform`](../terraform/SKILL.md) skill — generic baseline.
+- [`review-mcaf`](../review-mcaf/SKILL.md) skill — qualitative module review.
+- `GUIDE.md` — the MCAF way-of-working reference.

--- a/skills/mcaf-module/SKILL.md
+++ b/skills/mcaf-module/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcaf-module
-description: Author or structurally review a Schuberg Philis MCAF Terraform module (`terraform-<provider>-mcaf-<name>`). Use when creating a new MCAF module, modifying an existing one, or reviewing a PR against one. This skill layers MCAF-specific rules on top of the generic `terraform` skill — start there for baseline guidance (module layout, variable/output design, testing, CI, security) and come here for the Schuberg Philis specifics (`terraform.tf` not `versions.tf`, reuse of `mcaf-github-workflows`, `local.tags` with `ManagedBy`, native `terraform test` with `mock_provider`, conventional-commit PR labels, release-drafter flow, and the recurring anti-patterns observed across the 91-module corpus). For a full qualitative review producing good/bad/verdict reports, use the `review-mcaf` skill instead.
+description: Author or structurally review a Schuberg Philis MCAF Terraform module (`terraform-<provider>-mcaf-<name>`). Use when creating a new MCAF module, modifying an existing one, or reviewing a PR against one. This skill layers MCAF-specific rules on top of the generic `terraform` skill — start there for baseline guidance (module layout, variable/output design, testing, CI, security) and come here for the Schuberg Philis specifics (`terraform.tf` not `versions.tf`, reuse of `mcaf-github-workflows`, `var.tags` on every taggable resource, native `terraform test` with `mock_provider`, conventional-commit PR labels, release-drafter flow, and the recurring anti-patterns observed across the 91-module corpus). For a full qualitative review producing good/bad/verdict reports, use the `review-mcaf` skill instead.
 ---
 
 # MCAF module
@@ -23,7 +23,6 @@ For a full **qualitative** review (good/bad, design critique, verdict), use `rev
 - **AWS full-surface**: `terraform-aws-mcaf-s3`
 - **AWS thin wrapper**: `terraform-aws-mcaf-kms`
 - **Azure full-surface**: `terraform-azure-mcaf-storage-account`
-- **Azure with correct `local.tags` + native tests**: `terraform-azure-mcaf-container-app-environment`
 - **GitHub / GitLab / TFE reference**: `terraform-github-mcaf-repository`
 - **Shared CI**: `schubergphilis/mcaf-github-workflows`
 
@@ -41,8 +40,11 @@ These override or tighten the base skill. Everything not listed here defers to t
 
 ### Version pinning floors
 
-- Terraform: `required_version` must allow the newest Terraform (no upper bound). Any floor is acceptable.
-- AWS: `>= 6.0, < 7.0`. Azurerm: `>= 4, < 5.0`. AzureAD: `>= 3, < 4.0`. Datadog: `>= 3.39, < 4.0`.
+The exact floor number is not important — what matters is the **bounds**: a floor-only constraint for Terraform and most providers (no upper bound), and a major-version range for AzureAD, Azurerm, and Datadog (floor + upper bound at the next major). Don't bikeshed the minor; just ensure the constraint shape is correct.
+
+- Terraform: `required_version` must allow the newest Terraform (no upper bound). Any floor is acceptable (e.g. `">= 1.9"`).
+- AWS: `>= 6` (no upper bound).
+- AzureAD: `>= 3, < 4`. Azurerm: `>= 4, < 5`. Datadog: `>= 3, < 4`. Upper bound at the next major.
 
 ### Resource labels
 
@@ -52,16 +54,7 @@ These override or tighten the base skill. Everything not listed here defers to t
 
 ### Tags
 
-Mandatory pattern, not optional:
-
-```hcl
-# locals.tf
-locals {
-  tags = merge(var.tags, { ManagedBy = "Terraform" })
-}
-```
-
-Every taggable resource references `local.tags`. No `try(var.tags)` cargo-cult.
+Every taggable resource references `var.tags`. No `try(var.tags)` cargo-cult. No `local.tags` indirection unless the module genuinely needs to inject extra tags.
 
 ### CI via `mcaf-github-workflows`
 
@@ -85,45 +78,9 @@ Do not hand-edit these files. If you need different behaviour, change it upstrea
 
 ### Pre-commit
 
-```yaml
-repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
-    hooks:
-      - id: check-json
-      - id: check-merge-conflict
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-yaml
-      - id: check-added-large-files
-      - id: pretty-format-json
-        args: [--autofix]
-      - id: detect-aws-credentials
-        args: [--allow-missing-credentials]
-      - id: detect-private-key
-  - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.98.1
-    hooks:
-      - id: terraform_fmt
-      - id: terraform_tflint
-      - id: terraform_docs
-      - id: terraform_validate
-  - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 3.2.388
-    hooks:
-      - id: checkov
-        args:
-          - --download-external-modules
-          - "true"
-          - --quiet
-          - --compact
-          - --skip-check
-          - CKV_GIT_5,CKV_GLB_1,CKV_TF_1
-          - --skip-path
-          - examples/*
-```
+The canonical config is maintained in [`mcaf-github-workflows/sync-root/.pre-commit-config.yaml`](https://github.com/schubergphilis/mcaf-github-workflows/blob/main/sync-root/.pre-commit-config.yaml). Read the repository's copy for exact hooks and versions.
 
-Skipped checkov rules (policy):
+Key policy notes on skipped checkov rules:
 
 - `CKV_GIT_5` / `CKV_GLB_1` — MCAF requires ≥1 approval, not ≥2.
 - `CKV_TF_1` — modules use semver tags, not commit SHAs.
@@ -184,7 +141,7 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 Block new code adding instances of these:
 
 - Terraform `required_version` set and allows the newest Terraform (no upper bound). Any floor is acceptable.
-- AWS `>= 6`, Azurerm `>= 4`, AzureAD `>= 3`, Datadog `>= 3`.
+- AWS `>= 6` (no upper bound). AzureAD `>= 3, < 4`, Azurerm `>= 4, < 5`, Datadog `>= 3, < 4` (upper bound at next major).
 - No exact or patch-tight provider pins inside a module.
 - No deprecated AWS resources (`aws_s3_bucket_object`, inline `aws_s3_bucket` sub-blocks).
 - No deprecated HCL constructors (`list(...)`, `map(...)`).
@@ -232,7 +189,7 @@ Bug classes spotted in the corpus worth explicit spot-checks:
 3. Replace `.github/workflows/*` and `.pre-commit-config.yaml` with current versions from `mcaf-github-workflows` (preserve `DO NOT CHANGE` header).
 4. Write `terraform.tf` with a `required_version` that allows the newest Terraform (e.g. `">= 1.9"` — floor only, no upper bound) and provider ranges.
 5. Write `variables.tf` with types, descriptions, validations, `sensitive`/`nullable` as needed. Follow arg order rule.
-6. Write `main.tf`. Use `locals.tags = merge(var.tags, { ManagedBy = "Terraform" })`; reference `local.tags` on every taggable resource. Use canonical label (`"default"` or `"this"`).
+6. Write `main.tf`. Reference `var.tags` on every taggable resource. Use canonical label (`"default"` or `"this"`).
 7. Write `outputs.tf`: `id` / `arn` / `name` first, each with `description`. No whole-resource dumps.
 8. Write `examples/default/main.tf` using `source = "../../"`, no `version =`.
 9. Add one example per major feature branch.
@@ -253,7 +210,7 @@ In order, fail fast:
 3. **`terraform.tf`** — provider bumps widen the upper bound? `required_version` not lowered?
 4. **Variables** — new var has `description` + `type`? enumerated values have `validation`? secrets `sensitive = true`? rename/retype triggers `breaking` label + `UPGRADING.md`? arg order inside block correct?
 5. **Outputs** — `description` present? no whole-resource leak? sensitive values marked?
-6. **Tags** — new taggable resource references `local.tags`? `try(var.tags)` removed if present?
+6. **Tags** — new taggable resource references `var.tags`? `try(var.tags)` removed if present?
 7. **Examples** — at least one exercises the change? still valid?
 8. **Tests** — new `run` block covers the new branch? `expect_failures` for negatives?
 9. **Workflows / pre-commit** — untouched? If edited: reject and point at `mcaf-github-workflows`.
@@ -270,9 +227,7 @@ In order, fail fast:
 - Mock provider omitted from tests — test tries to hit a real cloud.
 - Dumping every attribute into `outputs.tf`.
 - Mixed default representations: `""` vs `null`. Prefer `null`.
-- Merging `var.tags` directly at each resource.
 - Creating a resource group inside a module when caller should own it.
-- Forgetting to apply a PR label.
 
 ## Useful one-liners
 

--- a/skills/review-mcaf/SKILL.md
+++ b/skills/review-mcaf/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: review-mcaf
+description: Perform a qualitative MCAF module review covering best practices, usability, lifecycle currency, supply chain, security defaults, and design smells — and produce a good/bad/verdict markdown report. Use when the user asks for an "MCAF review", wants to assess whether a module is ship-ready, wants to triage multiple MCAF modules, asks "is this module any good?", or references `REVIEW.md`. For a single repo the skill produces one markdown section; for many it dispatches parallel subagents and stitches them into one file.
+---
+
+# review-mcaf
+
+Qualitative review for Schuberg Philis MCAF Terraform modules. This is the judgement layer on top of the structural checklists in the [`terraform`](../terraform/SKILL.md) and [`mcaf-module`](../mcaf-module/SKILL.md) skills — what the eye catches that a rubric cannot:
+
+- whether abstractions are right-sized,
+- whether security defaults are safe,
+- whether the README actually teaches,
+- whether tests are meaningful or token,
+- whether the module has correctness bugs or dead code,
+- whether LCM / supply-chain rot is visible.
+
+The ground truth for every rule lives in [`../mcaf-module/GUIDE.md`](../mcaf-module/GUIDE.md). This skill is the playbook for applying it.
+
+## When to use this skill
+
+Trigger on any of:
+
+- "review this MCAF module" / "do an MCAF review" / "check it against MCAF best practices"
+- "is `terraform-<provider>-mcaf-<name>` good?"
+- "review all MCAF modules in `repos/`"
+- "assess these modules for ship-readiness"
+- After substantive changes to an MCAF module, before creating the PR or cutting a release
+- User references `REVIEW.md` in conversation
+
+For small one-rule structural questions (e.g. "does this look MCAF-compliant?"), use `mcaf-module` instead — it's lighter-weight.
+
+## Target discovery (where "the modules" actually live)
+
+The skill does not assume a fixed directory. Work out the target set from what the user said:
+
+- **"review this module"** / no path / inside a repo → target is the **current working directory**. Confirm it looks like an MCAF module (`terraform-<provider>-mcaf-<name>` name, a `main.tf` or `terraform.tf` at the root) before proceeding.
+- **Explicit single path** ("review `~/code/terraform-aws-mcaf-s3`") → that directory.
+- **Container directory** ("review all MCAF modules in `./repos`", "review the modules under `~/git/schuberg/`") → recurse one or two levels and collect every directory whose **basename** matches `^terraform-[a-z]+-mcaf-` and which contains a `.tf` file at its root. Do not descend into `examples/`, `modules/`, `tests/`, `.terraform/`, `.git/`.
+- **Org-wide** ("review all MCAF modules", no local path) → enumerate with `gh api orgs/schubergphilis/repos --paginate -q '.[] | select(.archived==false) | select(.name|test("^terraform-[a-z]+-mcaf-")) | {name, ssh_url, pushed_at}'`. Clone what's missing shallowly (`git clone --depth 1`) into a working dir the user picked (or `./repos/<provider>/<name>/` by default). Ask before cloning ~90 repos unprompted.
+
+Derive `<provider>` from the second token of the repo name (`terraform-aws-…` → `aws`, `terraform-azure-…` → `azure`, etc.; anything else → `other`). Use this for the output grouping and for applying provider-specific conventions (AWS label `"default"` vs Azure label `"this"`, taggable-provider rule, etc.).
+
+If exactly **one** target resolves, produce a single section. If **≥2**, follow the "Many-module review procedure" at the bottom of this file.
+
+## What to read for each module
+
+**Always** (cheap and essential):
+- `main.tf`
+- `variables.tf` (and `variables.*.tf` if domain-split)
+- `outputs.tf`
+- `README.md` (prose sections; the `BEGIN_TF_DOCS` block is auto-generated — skim only)
+
+**If present**:
+- `tests/*.tftest.hcl` and `tests/setup/` — test depth matters more than test presence
+- `.github/workflows/*.y*ml` — look for stale action pins and flagged publishers
+- `locals.tf`, `data.tf` — locals that recompute vs locals that extract invariants
+- `modules/*/` — sub-module quality is part of the review
+- `CHANGELOG.md`, `UPGRADING.md` — evidence of deliberate lifecycle management
+- `package.json` / `requirements.txt` if the module ships Lambda — supply-chain check
+- `terraform.tf` — currency of floors and pins
+
+**Skip**:
+- Every other module in the corpus; do not try to cross-reference.
+- The auto-generated portion of `README.md`.
+- Lock files, `.terraform/`.
+
+## The review dimensions
+
+Walk each dimension for every module. Note concrete findings — cite variable/resource/file names. Generic bullets fail the review.
+
+1. **Repository hygiene** — canonical filenames (`terraform.tf`, `main.tf`, `Taskfile.yaml`); no camelCase file names; no stray `VERSION` / `INFO.md` / `example.tfvars`; `README copy.md` or other accidental commits.
+2. **Variable design** —
+   - Every `variable` has `description` + `type` in the canonical arg order (per `../mcaf-module/GUIDE.md §3`): `type` → `default` → `description` → `nullable` / `sensitive` → `validation`. `description` before `type` or `validation` before `type`/`description` are the common violations.
+   - Complex shapes use `object({ ... optional(..., default) ... })` rather than flat var sprawl.
+   - Constrained values have `validation` with an actionable `error_message`.
+   - `sensitive = true` on credentials; `nullable = false` on truly-required inputs.
+   - `default = null` (not `""`) for "unset".
+   - No flat-variable passthroughs that duplicate a child module's surface.
+3. **Resource / logic quality** —
+   - Provider-canonical labels (`"default"` on AWS/GitHub/Datadog/TFE/GitLab; `"this"` on Azure).
+   - No copy-paste bugs inside `for_each` blocks (very common: `var.x` where `each.value.x` was meant).
+   - Preconditions (`lifecycle { precondition { ... } }`) used for cross-field invariants.
+   - `moved {}` blocks for refactors — state-preserving renames.
+   - No dead variables / locals / files.
+   - No `null_resource` / deprecated resources (`aws_s3_bucket_object`, `azurerm_function_app`).
+   - Resource group ownership is caller's responsibility on Azure — flag any internal `azurerm_resource_group.this` with a `count` toggle.
+4. **Outputs** —
+   - `description` on every output; first are `id` / `arn` / `name`.
+   - No whole-resource dumps (`output "resource" { value = aws_x.this }`).
+   - Sensitive values marked `sensitive = true`.
+   - Minimum useful surface — not every attribute re-exported.
+5. **Tags** —
+   - `variable "tags"` defaults to `{}` (not `null`).
+   - `local.tags = merge(var.tags, { ManagedBy = "Terraform" })` pattern.
+   - Every taggable resource uses `local.tags`.
+   - No `try(var.tags)` cargo-cult.
+   - No hard-coded tag keys buried inside individual resources.
+6. **Examples** — `examples/default/` present; additional examples cover major feature branches; each is valid HCL; no ad-hoc `## Usage` HCL blob in README.
+7. **Tests** — native `terraform test` with `mock_provider`; multiple `run` blocks per behaviour; `expect_failures` for negative paths; tests assert on *derived* values (not just re-echoing defaults).
+8. **CI & pre-commit** — five standard workflows from `mcaf-github-workflows` with the `DO NOT CHANGE` header intact; no hand-edits; pre-commit config includes the core hooks.
+9. **Lifecycle / currency** —
+   - Terraform `required_version` allows the newest Terraform (no upper bound).
+   - AWS `>= 6`, Azurerm `>= 4`, AzureAD `>= 3`, Datadog `>= 3`.
+   - No exact or patch-tight provider pins.
+   - No deprecated HCL or deprecated provider resources.
+   - No action pins older than current (`setup-terraform@v3`, `checkout@v4`, `github-script@v7`, `terraform-docs/gh-actions@v1.3.0`).
+   - Child MCAF modules referenced via registry + `version = "~> X.Y"`, not `?ref=vX.Y.Z`.
+10. **Supply chain** —
+    - No `@master` / `@main` action refs.
+    - No `uses:` with no `@ref` at all (unpinned).
+    - No "weird" ref shapes (non-SHA, non-semver, non-branch) — flag and investigate.
+    - No flagged publishers (`Dirrk`, `triat`, `danielchabr`, `anothrNick`, `jessfraz`).
+    - Non-trusted publishers → SHA-pinned (40-char hex).
+    - Lambda Python deps `==X.Y.Z`; Node deps have a committed lockfile.
+    - No floating `:latest` / `:main` image defaults.
+11. **README usefulness** — explains gotchas a caller cannot infer from the inputs table (multi-account aliased providers, operational caveats, lifecycle warnings); no hand-written inputs table; has the version-pinning `IMPORTANT` banner; has `## Licensing` footer.
+12. **Security defaults** — encryption on by default; public access off; TLS ≥ 1.2; secrets not logged; IAM principle-of-least-privilege; broad `0.0.0.0/0` only where explicitly justified.
+13. **Recency** — derive last-push from `git log -1 --format=%cI` (or the cloned repo's HEAD date). Treat **>24 months** with no push as a strong push toward `deprecate-or-consolidate` unless the module is clearly "done" (stable, small, no drift). **>12 months** is a soft signal — weigh alongside the other dimensions, don't let it drive the verdict alone.
+
+## Recurring anti-patterns to hunt for
+
+Each of these appears across the corpus. Check every module for them:
+
+1. **Whole-resource outputs** leaking sensitive attributes.
+2. **`try(var.tags)`** cargo-cult.
+3. **Two sources of truth for resource group** on Azure.
+4. **Hard-pinned child-module `?ref=vX.Y.Z`** inside a module.
+5. **Empty `outputs.tf`** — module is a black box.
+6. **Missing `sensitive = true`** on passwords/keys/tokens/kubeconfig.
+7. **Floating `:latest` / `:main`** image/version defaults.
+8. **Dead variables / locals / files / commented-out blocks**.
+9. **File-naming drift** (camelCase, `backend.tf`, `module.tf`, `versions.tf`, `Taskfile.yml`).
+10. **Nested ternaries over `optional(field, default)`** — wrong type shape.
+
+Also spot-check for the concrete bug classes observed in the corpus:
+
+- Swapped output wiring.
+- `each.value.*` vs `var.*` copy-paste inside `for_each`.
+- Policy conditions comparing `.name` to an ARN.
+- `archive_file.output_path` as a relative path.
+- References to `azurerm_resource_group.this` that is never declared.
+- Cron expressions with the wrong number of fields.
+
+## Output format
+
+**One module** → one markdown section, exactly this shape:
+
+```markdown
+### `<module-name>`
+
+**Last pushed:** YYYY-MM-DD  <!-- optional, only if quickly derivable -->
+
+**Good:**
+- Concrete bullet citing `variable_name` / `resource "..." "..."` / file path.
+- 3–6 bullets total.
+
+**Bad:**
+- Concrete bullet with specifics.
+- 3–6 bullets total.
+
+**Verdict:** One sentence. Pick one tag:
+- `keep-as-is` — reference quality, clone when starting a new module.
+- `minor-cleanup` — healthy design, small fixes (descriptions, pin bumps, tag merge, output polish).
+- `major-refactor` — real design or correctness issues; reshape, fix bugs, rewrite sections.
+- `deprecate-or-consolidate` — empty shell, abandoned, or duplicate with a better sibling.
+```
+
+Hard rules on the review prose:
+
+- **≤180 words per module**. Terse is better.
+- **Concrete, not generic.** "Missing `sensitive = true` on `variable "api_key"`" beats "sensitive values not marked". If you cannot cite a name, you have not read carefully enough.
+- **Do not repeat structural checklist items** unless they are the headline issue. The `mcaf-module` skill handles "missing Taskfile" etc.; this skill adds the judgement layer.
+- **Modules that fail most of the structural checklist**: be blunt about whether they are worth rescuing. If the repo is a README-only scaffold, `deprecate-or-consolidate` is the honest answer.
+- **No preamble, no trailing summary** per section.
+
+**Many modules** → concatenate sections in this order:
+
+1. H1 title + one-paragraph intro.
+2. "Verdict distribution" table (counts per tag).
+3. Per-tag headline lists:
+   - 🥇 `keep-as-is` — named bullets with module + static %.
+   - 🗑️ `deprecate-or-consolidate` — named bullets with one-line reason.
+   - 🔧 `major-refactor` — table with headline issue per module.
+4. "Cross-corpus standout findings" — systemic patterns you saw recurring.
+5. All per-module sections grouped roughly by provider (AWS → Azure → Other), alphabetical within group.
+
+## Single-module review procedure
+
+1. Confirm the target path. Assume `repos/<provider>/<name>/` or a direct repo path supplied by the user.
+2. Read the files listed under "What to read" above.
+3. Walk the 13 review dimensions and the 10 anti-pattern hunts.
+4. Draft the section in the exact format.
+5. Keep ≤180 words. Trim generic bullets first.
+
+## Many-module review procedure
+
+When reviewing more than ~5 modules at once:
+
+1. List the target modules. If last-pushed dates are easy to derive (e.g. from `git log`), include them in the section header for grounding.
+2. Bucket into groups of ~10. Dispatch **parallel subagents** (one per bucket) via the `Task` / `Agent` tool. Each subagent gets:
+   - The review dimensions + anti-pattern hunts (link to this skill or inline them).
+   - The list of module paths for its bucket.
+   - The exact output format.
+   - Explicit instruction to return ONLY concatenated markdown sections, no preamble.
+3. As each agent finishes, stash its output to a scratch file (e.g. `/tmp/review-bucket-<N>.md`).
+4. Once all complete, stitch into a single file. Compute the verdict distribution. Write the headline tables. Extract **cross-corpus findings** — only include a pattern if it appeared in **≥3 modules** (or ≥3 buckets, whichever is stricter). Single-module oddities belong in their own section, not the cross-corpus roll-up.
+5. Save to `REVIEW.md` at the repo root (or a user-specified path).
+
+Parallel-dispatch tips:
+
+- Each subagent should be briefed to skim `../mcaf-module/GUIDE.md` §3/§5/§7/§11 first and reference it as source of truth.
+- Tell each subagent the provider-specific conventions: AWS label `"default"`, Azure label `"this"`; Azure gold standard is `terraform-azure-mcaf-storage-account`, AWS gold standard is `terraform-aws-mcaf-s3`.
+- When the first agent returns, validate its format before the rest finish — catches prompt-level drift early.
+- Do not tail the agent transcript files — they are JSONL and will blow context. Save the final output only.
+
+## Edge cases
+
+- **Repo with no Terraform code** (LICENSE + README only) → `deprecate-or-consolidate`. Do not pretend there is substance to review.
+- **Repo that fails `terraform validate`** (missing resources, empty `terraform.tf`) → lead the **Bad** bullets with the plan-breaking issue, verdict `major-refactor` or `deprecate-or-consolidate`.
+- **Non-AWS/Azure providers** (gitlab, tfe, datadog) — do not penalise for AWS/Azure conventions that don't apply (e.g. no `tags` on GitLab). Use `terraform-github-mcaf-repository` as the cross-provider reference.
+- **Private providers** (`schubergphilis/mcaf`, etc.) — note in the review if undocumented.
+- **Module that embeds `provider "x" { ... }`** — always a **Bad** bullet and usually `major-refactor`; providers belong in the root caller.
+
+## Don't
+
+- Do not run automated scorers or write Python scripts to produce this report. This skill is prose judgement; mechanical checks are the other skill's job.
+- Do not duplicate the structural checklist line-by-line — that is the `mcaf-module` skill's job.
+- Do not generate generic bullets. Every bullet cites a concrete name.
+- Do not add a "Neutral" or "Observations" section — Good / Bad / Verdict only.
+- Do not invent findings. If you did not read the file, do not write a bullet about it.
+
+## Related
+
+- [`../mcaf-module/GUIDE.md`](../mcaf-module/GUIDE.md) — the source of truth for every rule cited above.
+- [`terraform`](../terraform/SKILL.md) skill — generic Terraform/OpenTofu baseline.
+- [`mcaf-module`](../mcaf-module/SKILL.md) skill — structural checklist for authoring and PR review.

--- a/skills/review-mcaf/SKILL.md
+++ b/skills/review-mcaf/SKILL.md
@@ -91,16 +91,15 @@ Walk each dimension for every module. Note concrete findings — cite variable/r
    - Minimum useful surface — not every attribute re-exported.
 5. **Tags** —
    - `variable "tags"` defaults to `{}` (not `null`).
-   - `local.tags = merge(var.tags, { ManagedBy = "Terraform" })` pattern.
-   - Every taggable resource uses `local.tags`.
+   - Every taggable resource references `var.tags`. No `local.tags` indirection unless the module genuinely needs to inject extra tags.
    - No `try(var.tags)` cargo-cult.
    - No hard-coded tag keys buried inside individual resources.
 6. **Examples** — `examples/default/` present; additional examples cover major feature branches; each is valid HCL; no ad-hoc `## Usage` HCL blob in README.
 7. **Tests** — native `terraform test` with `mock_provider`; multiple `run` blocks per behaviour; `expect_failures` for negative paths; tests assert on *derived* values (not just re-echoing defaults).
 8. **CI & pre-commit** — five standard workflows from `mcaf-github-workflows` with the `DO NOT CHANGE` header intact; no hand-edits; pre-commit config includes the core hooks.
 9. **Lifecycle / currency** —
-   - Terraform `required_version` allows the newest Terraform (no upper bound).
-   - AWS `>= 6`, Azurerm `>= 4`, AzureAD `>= 3`, Datadog `>= 3`.
+   - Terraform `required_version` allows the newest Terraform (no upper bound). The exact floor is not important — just verify the constraint shape.
+   - AWS `>= 6` (no upper bound). AzureAD `>= 3, < 4`, Azurerm `>= 4, < 5`, Datadog `>= 3, < 4` (upper bound at next major). Don't bikeshed the minor; focus on whether the bounds are correct.
    - No exact or patch-tight provider pins.
    - No deprecated HCL or deprecated provider resources.
    - No action pins older than current (`setup-terraform@v3`, `checkout@v4`, `github-script@v7`, `terraform-docs/gh-actions@v1.3.0`).

--- a/skills/terraform/SKILL.md
+++ b/skills/terraform/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: terraform
+description: Generic Terraform / OpenTofu guidance — module structure, variable + output design, block ordering, version pinning, native `terraform test`, CI/CD, security scanning, and state hygiene. Use when authoring or reviewing any Terraform/OpenTofu module, making IaC architecture decisions, picking a testing approach, setting up pipelines, or debugging state. For Schuberg Philis MCAF modules, the MCAF-specific overlays live in the `mcaf-module` and `review-mcaf` skills — use this one for baseline rules that apply regardless of organisation.
+---
+
+# Terraform / OpenTofu — baseline way of working
+
+Inspired by Anton Babenko's [`terraform-skill`](https://github.com/antonbabenko/terraform-skill) and the patterns at terraform-best-practices.com. This is the generic base; organisation-specific overlays live in separate skills.
+
+## When to use this skill
+
+Use when:
+
+- Creating or reviewing a Terraform/OpenTofu module.
+- Choosing between testing approaches (`validate`, plan tests, native `terraform test`, Terratest).
+- Structuring multi-environment deployments.
+- Setting up CI/CD for IaC.
+- Reviewing or refactoring existing configs.
+- Deciding between module patterns or state-management approaches.
+
+Don't use for:
+
+- Basic HCL syntax questions.
+- Provider-specific API reference (link to upstream docs).
+
+## Reference files
+
+Detailed guidance lives in `references/`:
+
+- [`module-patterns.md`](references/module-patterns.md) — module hierarchy, layout, variable/output design, tag patterns, anti-patterns.
+- [`code-patterns.md`](references/code-patterns.md) — block ordering, `count` vs `for_each`, `optional(…)`, `moved {}`, version management.
+- [`testing.md`](references/testing.md) — the decision matrix across `terraform validate`, plan tests, native `terraform test`, and Terratest.
+- [`ci-cd.md`](references/ci-cd.md) — GitHub Actions shape, conventional commits, release-drafter, pre-commit.
+- [`security-compliance.md`](references/security-compliance.md) — checkov/tfsec/trivy, secrets hygiene, state security.
+- [`quick-reference.md`](references/quick-reference.md) — cheat sheets, decision flowchart, troubleshooting.
+
+## Core principles
+
+### 1. Module hierarchy
+
+| Level | Scope | Example |
+|---|---|---|
+| **Resource module** | One logical group of connected resources | VPC + subnets; Security group + rules |
+| **Infrastructure module** | A set of resource modules for one purpose in one region/account | Landing zone in one account |
+| **Composition** | A complete deployment, potentially multi-region/account | Whole org |
+
+Build bottom-up: resource → resource module → infrastructure module → composition. Never skip a level by inlining across levels.
+
+### 2. Repository layout for a resource module
+
+```
+<root>/
+├── main.tf
+├── variables.tf           # every variable with type + description
+├── outputs.tf             # every output with description
+├── terraform.tf           # required_version + required_providers
+├── locals.tf              # only if non-empty
+├── data.tf                # only if non-empty
+├── README.md              # prose + auto-injected terraform-docs
+├── CHANGELOG.md
+├── LICENSE
+├── .github/workflows/     # CI
+├── .pre-commit-config.yaml
+├── examples/              # one subdir per scenario, each runnable
+│   ├── default/
+│   └── <feature>/
+└── tests/                 # native terraform test
+    ├── main.tftest.hcl
+    └── setup/             # optional fixture module
+```
+
+### 3. Version pinning
+
+```hcl
+terraform {
+  required_version = ">= 1.9"   # a reasonable modern floor, no upper bound
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0, < 7.0"  # range, not exact
+    }
+  }
+}
+```
+
+- `required_version` floor-only with `>=`. No upper bound on Terraform.
+- Provider `version` expressed as `>= X.Y, < (X+1).0`. Never `= X.Y.Z` (exact) in a reusable module.
+- Patch-tight (`~> X.Y.Z`) is almost always wrong — it blocks security patches.
+
+### 4. Variables
+
+```hcl
+variable "name" {
+  type        = string
+  description = "The name of the resource. Conflicts with `name_prefix`."
+  default     = null
+}
+
+variable "mode" {
+  type        = string
+  default     = null
+  description = "The operating mode."
+
+  validation {
+    condition     = var.mode == null || contains(["A", "B"], var.mode)
+    error_message = "mode must be one of A or B."
+  }
+}
+```
+
+Rules:
+
+- Every variable has `type` + `description`.
+- Internal arg order: `type` → `default` → `description` → `nullable` → `sensitive` → `validation`.
+- Prefer complex typed objects with `optional(field, default)` over flat variable sprawl.
+- Use `validation` for enumerated values, regex constraints, cross-field invariants.
+- `sensitive = true` on secrets.
+- `nullable = false` when `null` is not a valid caller value.
+- Use `default = null` for "unset", not `""`.
+- Snake_case names. Booleans read as statements of state (`versioning`, not `enable_versioning`).
+- No redundant prefixes (`arn`, not `bucket_arn`).
+
+### 5. Outputs
+
+- Every output has a `description`.
+- First outputs: `id`, `arn`, `name` — whatever maps to downstream caller references.
+- Mark sensitive outputs `sensitive = true`.
+- **Never return whole resources.** `output "resource" { value = aws_x.this }` leaks every attribute, including sensitive ones. Curate.
+- Minimum useful surface — not every attribute re-exported.
+
+### 6. Tags (cloud providers that support them)
+
+```hcl
+# locals.tf
+locals {
+  tags = merge(var.tags, { ManagedBy = "Terraform" })
+}
+
+# main.tf
+resource "aws_s3_bucket" "default" {
+  # ...
+  tags = local.tags
+}
+```
+
+- Expose `variable "tags"` as `map(string)` with `default = {}`.
+- Centralise the merge in `locals.tags`. Never hard-code tag keys in individual resources.
+- Drop `try(var.tags, {})` noise — `var.tags` has a default, `try()` around it hides type errors.
+
+### 7. Testing
+
+Use the layered strategy in [`references/testing.md`](references/testing.md):
+
+1. **Pre-commit**: `terraform fmt`, `tflint`, `terraform validate`, `terraform_docs`, `checkov`/`tfsec`/`trivy`.
+2. **CI static**: same tools, plus per-example `terraform init && terraform validate`.
+3. **Native `terraform test`**: `mock_provider`, `run` blocks, `assert`/`expect_failures`. Free of cloud credentials, fast.
+4. **Terratest** (Go): only when you need real apply against a real cloud.
+
+Prefer native tests unless you actually need to hit a cloud. Keep tests under `tests/`.
+
+### 8. CI/CD
+
+At minimum:
+
+- PR validation (title format, labels).
+- Terraform validation (fmt + lint + validate on every example + `terraform test`).
+- Docs injection (`terraform-docs` into README).
+- Security scan (checkov).
+- Release automation (release-drafter + CHANGELOG).
+
+See [`references/ci-cd.md`](references/ci-cd.md) for GitHub Actions shape.
+
+### 9. Security and state
+
+- Run checkov in pre-commit + CI. Skip rules only with explicit rationale in comments.
+- Never commit provider credentials, `.terraform/`, lock files for root modules where they could leak.
+- State: remote backend with locking. Encrypt at rest. Never share state across environments.
+- Secrets: caller passes ARNs/IDs of secret managers; modules don't take plaintext secrets. If they must, mark `sensitive = true`.
+
+### 10. Release flow
+
+- Conventional-commit PR titles: `feat`, `fix`, `breaking`, `docs`, `chore`.
+- Labels drive version bump: `breaking` → major; `feat`/`enhancement` → minor; `fix`/`chore`/`docs` → patch.
+- `release-drafter` maintains a draft release note on every merge; publish when ready.
+- Add `UPGRADING.md` entries for breaking changes.
+
+## Module anti-patterns
+
+Things that bite teams repeatedly:
+
+- Whole-resource outputs that leak sensitive state.
+- Hard-pinned child-module refs (`source = "…?ref=vX.Y.Z"`) — propagate version debt.
+- Two sources of truth for the same input (a flat `var.name` AND a nested `var.obj.name`).
+- `try(var.tags)` cargo-cult around variables that already have a default.
+- `default = null` on required inputs — contradicts the description.
+- Empty `outputs.tf` — module is a black box.
+- Missing `sensitive = true` on passwords/keys/tokens.
+- Floating `:latest` / `:main` image/version defaults — non-idempotent.
+- Dead variables / locals / files.
+- File-naming drift (camelCase, `backend.tf`/`module.tf`/`versions.tf` in place of canonical names).
+- Nested ternaries where `optional(field, default)` would do it.
+- `null_resource` / deprecated resources (`aws_s3_bucket_object`, `azurerm_function_app`).
+
+## Decision quick-reference
+
+- **Alphabetical or grouped variable order?** Either, but pick one per repo. CI's `terraform-docs --sort-by required` normalises the rendered README regardless.
+- **`count` vs `for_each`?** `for_each` on maps/sets for stable keys. `count` only when the multiplicity is truly positional.
+- **`locals.tf` or inline `locals {}`?** Separate file when you have >~3 locals or when locals cross domains.
+- **Providers in the module or in the caller?** In the caller. Modules use `configuration_aliases` only when they genuinely need multi-provider orchestration (e.g. cross-account S3 replication).
+
+## Further reading
+
+- `references/module-patterns.md`
+- `references/code-patterns.md`
+- `references/testing.md`
+- `references/ci-cd.md`
+- `references/security-compliance.md`
+- `references/quick-reference.md`

--- a/skills/terraform/SKILL.md
+++ b/skills/terraform/SKILL.md
@@ -78,14 +78,14 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0, < 7.0"  # range, not exact
+      version = ">= 6.0"            # floor only for AWS; some providers need an upper bound
     }
   }
 }
 ```
 
-- `required_version` floor-only with `>=`. No upper bound on Terraform.
-- Provider `version` expressed as `>= X.Y, < (X+1).0`. Never `= X.Y.Z` (exact) in a reusable module.
+- `required_version` floor-only with `>=`. No upper bound on Terraform. The exact floor is not important — focus on the constraint shape.
+- Provider `version` — floor-only for most providers (no upper bound). Some providers need an upper bound at the next major. Never `= X.Y.Z` (exact) in a reusable module.
 - Patch-tight (`~> X.Y.Z`) is almost always wrong — it blocks security patches.
 
 ### 4. Variables
@@ -132,20 +132,14 @@ Rules:
 ### 6. Tags (cloud providers that support them)
 
 ```hcl
-# locals.tf
-locals {
-  tags = merge(var.tags, { ManagedBy = "Terraform" })
-}
-
-# main.tf
 resource "aws_s3_bucket" "default" {
   # ...
-  tags = local.tags
+  tags = var.tags
 }
 ```
 
 - Expose `variable "tags"` as `map(string)` with `default = {}`.
-- Centralise the merge in `locals.tags`. Never hard-code tag keys in individual resources.
+- Reference `var.tags` on every taggable resource. No `local.tags` indirection unless the module genuinely needs to inject extra tags.
 - Drop `try(var.tags, {})` noise — `var.tags` has a default, `try()` around it hides type errors.
 
 ### 7. Testing

--- a/skills/terraform/references/ci-cd.md
+++ b/skills/terraform/references/ci-cd.md
@@ -1,0 +1,202 @@
+# CI/CD
+
+> Part of: [`terraform`](../SKILL.md) skill.
+> Purpose: CI pipeline shape and release automation.
+
+## Minimum pipeline for a module
+
+Every module should ship these workflows (or their equivalent on GitLab CI / Azure DevOps / etc.):
+
+1. **PR validation** — title format (conventional commits), required labels.
+2. **Terraform validation** — fmt check, tflint, validate per example, `terraform test`, terraform-docs injection, checkov scan.
+3. **Label sync** — keep repo labels in sync with the standard set.
+4. **Release drafter** — maintain a draft release note on every merge.
+5. **Changelog update** — write CHANGELOG.md on publish.
+
+Factor these into **reusable workflows** rather than copy-pasting per repo. A central repo (e.g. `org/github-workflows`) owns the canonical set; module repos invoke them via `workflow_call` or copy with a `DO NOT CHANGE THIS FILE DIRECTLY` header plus a sync process.
+
+## GitHub Actions shape
+
+```yaml
+# .github/workflows/terraform-validation.yml
+name: terraform
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  TF_IN_AUTOMATION: 1
+
+jobs:
+  fmt-lint-validate-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+
+      - uses: terraform-linters/setup-tflint@v4
+        with:
+          github_token: ${{ github.token }}
+
+      - name: terraform fmt
+        run: terraform fmt -check -recursive
+
+      - name: tflint
+        run: |
+          tflint --format compact
+          for d in examples/*/; do
+            tflint --chdir="$d" --format compact
+          done
+
+      - name: terraform validate (per example)
+        run: |
+          for d in examples/*/; do
+            terraform -chdir="$d" init -backend=false
+            terraform -chdir="$d" validate -no-color
+          done
+
+      - name: terraform test
+        run: |
+          terraform init
+          terraform test
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - uses: terraform-docs/gh-actions@v1.3.0
+        with:
+          args: --sort-by required
+          git-commit-message: "docs(readme): update module usage"
+          git-push: true
+          output-file: README.md
+          output-method: inject
+          working-dir: .
+        continue-on-error: true
+
+  checkov:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bridgecrewio/checkov-action@v12
+        with:
+          directory: "/"
+          framework: terraform
+          output_format: sarif
+          quiet: true
+          skip_path: "examples/"
+```
+
+## Conventional commits
+
+Enforce PR title format via `amannn/action-semantic-pull-request@v5`. Allowed types:
+
+- `feat` / `feature` — minor bump
+- `fix` / `bug` — patch bump
+- `breaking` — major bump
+- `docs` / `documentation` — patch bump
+- `chore` — patch bump
+- `security` — patch bump
+- `enhancement` — minor bump
+
+Enforce a label on each PR from the same set so `release-drafter` can categorise.
+
+## release-drafter
+
+```yaml
+# .github/release-drafter-config.yaml
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: ":boom: Breaking Changes"
+    labels: [breaking]
+  - title: ":rocket: Features"
+    labels: [enhancement, feature]
+  - title: ":bug: Bug Fixes"
+    labels: [bug, fix]
+  - title: ":lock: Security"
+    labels: [security]
+  - title: ":memo: Documentation"
+    labels: [documentation, docs]
+  - title: ":wrench: Maintenance"
+    labels: [chore]
+version-resolver:
+  major:
+    labels: [breaking]
+  minor:
+    labels: [enhancement, feature]
+  patch:
+    labels: [bug, fix, security, documentation, docs, chore]
+  default: patch
+```
+
+Publish draft releases manually — don't auto-publish on merge unless you have a high-confidence release gate.
+
+## Cost optimization
+
+- **Use the smallest runner** that works. Most Terraform module CI fits on `ubuntu-latest`.
+- **Cache `terraform init` downloads** when CI runs the same modules repeatedly.
+- **Skip unchanged paths** on monorepos via `paths:` / `dorny/paths-filter`.
+- **Fan-in status checks** rather than requiring every job individually — faster feedback.
+
+## Automated cleanup
+
+For repos that create real cloud resources in CI:
+
+- Tag every resource with `CI=true, CI-Run=${{ github.run_id }}`.
+- Scheduled cleanup workflow that deletes tagged resources older than N hours.
+- Budget alarms on the CI account.
+
+## CI anti-patterns
+
+- **`continue-on-error: true`** on a validation step — silently passes broken PRs. Use only on the `terraform-docs` auto-commit step (which can fail for fork PRs).
+- **Using `actions/checkout@master`** or `@v1` / `@v2` / `@v3` — mutable or older. Pin to `@v4` or later, or SHA.
+- **`hashicorp/setup-terraform@v2`** — `@v3` is current.
+- **Running `terraform apply` on PRs** against real infra without sandboxing — costs money and risks real resources.
+- **Committing `.terraform/` or `*.tfstate`** — never. State belongs in a backend; `.terraform/` is build output.
+- **Ignoring checkov findings without `# checkov:skip=RULE_ID`** with a rationale comment nearby.
+
+## Shared workflow approach
+
+For an org with many modules, factor CI into a central `org/terraform-workflows` repo:
+
+```yaml
+# in a module repo: .github/workflows/terraform.yml
+name: terraform
+
+on:
+  pull_request:
+
+jobs:
+  terraform:
+    uses: org/terraform-workflows/.github/workflows/terraform.yml@v1
+    with:
+      examples: "examples/*"
+```
+
+Benefits:
+
+- One place to update the pipeline.
+- Consistent across the org.
+- Module repos only own module code, not CI plumbing.
+
+If your org uses a `DO NOT CHANGE THIS FILE DIRECTLY` copy-paste model instead of `workflow_call`, that works too — but you need a sync process to keep module repos current.
+
+## Action pinning
+
+| Pin style | When OK |
+|---|---|
+| SHA (`@abc123...40 chars`) | Always. Safest. |
+| Exact tag (`@v1.3.0`) | Acceptable for trusted publishers. |
+| Minor (`@v1.3`) | Acceptable for trusted publishers. |
+| Major (`@v1`) | Acceptable for trusted publishers only. Reject for unknown publishers. |
+| Branch (`@main`, `@master`) | **Never.** Mutable reference. |
+
+"Trusted" typically means `actions/*`, `github/*`, `hashicorp/*`, plus a short list of widely-audited community publishers. For any action from an unaudited publisher, SHA-pin or replace.

--- a/skills/terraform/references/code-patterns.md
+++ b/skills/terraform/references/code-patterns.md
@@ -1,0 +1,232 @@
+# Code patterns
+
+> Part of: [`terraform`](../SKILL.md) skill.
+> Purpose: HCL code structure, modern features, refactoring patterns.
+
+## Block ordering in a resource
+
+```hcl
+resource "aws_s3_bucket" "default" {
+  # 1. Meta-args
+  for_each = var.buckets
+
+  # 2. Identifying args
+  bucket        = each.key
+  bucket_prefix = each.value.prefix
+
+  # 3. Core config
+  force_destroy = each.value.force_destroy
+
+  # 4. Feature flags
+  object_lock_enabled = each.value.object_lock_mode != null
+
+  # 5. Nested blocks
+  grant {
+    permissions = ["FULL_CONTROL"]
+    type        = "CanonicalUser"
+    id          = each.value.owner_id
+  }
+
+  # 6. Tags (always last data arg)
+  tags = local.tags
+
+  # 7. Meta-blocks: lifecycle / depends_on
+  lifecycle {
+    prevent_destroy = each.value.protected
+  }
+}
+```
+
+## `count` vs `for_each`
+
+Default to `for_each` for nearly everything.
+
+| Situation | Use |
+|---|---|
+| Toggle a single resource on/off | `count = var.enabled ? 1 : 0` |
+| N instances where order matters | `count = length(var.items)` (rare) |
+| Multiple instances keyed by name/ID | `for_each = toset(var.items)` or `for_each = var.objects` |
+| Resource ID must survive reordering | `for_each` (always) |
+
+`count`-indexed resources have addresses like `aws_s3_bucket.default[0]`; reordering the input list causes Terraform to destroy/recreate. `for_each` maps avoid this.
+
+## Modern Terraform features (≥1.3)
+
+### `optional()` in object types
+
+```hcl
+variable "backup" {
+  type = object({
+    enabled        = optional(bool, false)
+    retention_days = optional(number, 30)
+    cross_region   = optional(object({
+      enabled = bool
+      region  = string
+    }))
+  })
+  default = {}
+}
+```
+
+Callers set only the fields they care about; unset fields use the declared default.
+
+### `moved { }` blocks (≥1.1)
+
+Refactor without destroying state:
+
+```hcl
+# moved.tf
+moved {
+  from = aws_s3_bucket.bucket
+  to   = aws_s3_bucket.default
+}
+```
+
+Use for:
+
+- Renames (fix typos, align with conventions).
+- Restructuring into `for_each`/submodules.
+
+### `check { }` blocks (≥1.5)
+
+Post-apply assertions with warnings rather than errors:
+
+```hcl
+check "tls_1_2_only" {
+  assert {
+    condition     = aws_api_gateway_domain_name.default.security_policy == "TLS_1_2"
+    error_message = "API Gateway domain must enforce TLS 1.2."
+  }
+}
+```
+
+### `precondition` / `postcondition` (≥1.2)
+
+Fail at plan-time with actionable messages:
+
+```hcl
+resource "aws_s3_bucket_logging" "default" {
+  lifecycle {
+    precondition {
+      condition     = var.logging.target_bucket != aws_s3_bucket.default.bucket
+      error_message = "Logging target bucket cannot be the bucket itself."
+    }
+  }
+  # …
+}
+```
+
+Preferred over `null_resource` with `triggers` for invariant checks.
+
+### Provider functions (≥1.8)
+
+```hcl
+resource "azurerm_private_endpoint" "default" {
+  # …
+  private_service_connection {
+    name                           = provider::azurerm::normalise_resource_id(var.target_id)
+    private_connection_resource_id = var.target_id
+  }
+}
+```
+
+## Version management
+
+### In a module
+
+- `required_version = ">= 1.9"` — floor only, no upper bound.
+- Providers as `>= X.Y, < (X+1).0` — range with a major ceiling.
+- Never `= X.Y.Z` (exact) in a module.
+- Avoid `~> X.Y.Z` (patch-tight) — blocks patches.
+
+### In a composition / root
+
+- Same floor pattern, plus a committed `.terraform.lock.hcl`.
+- Pin providers more tightly if you must, but in the root not in the module.
+
+## Refactoring patterns
+
+### Splitting a monolithic module
+
+1. Identify orthogonal concerns (networking vs compute vs data).
+2. Create new resource modules for each concern.
+3. In the old root, replace resources with `module "network" { source = "./modules/network" … }`.
+4. Add `moved {}` blocks mapping old addresses to new ones.
+5. Run `terraform plan` and verify no resources are destroyed.
+
+### Adding multiplicity after the fact
+
+Going from single to `for_each`:
+
+```hcl
+# Before
+resource "aws_s3_bucket" "default" { bucket = var.name }
+
+# After
+resource "aws_s3_bucket" "default" {
+  for_each = toset(var.names)
+  bucket   = each.value
+}
+
+moved {
+  from = aws_s3_bucket.default
+  to   = aws_s3_bucket.default["<original_name>"]
+}
+```
+
+## Locals for clarity
+
+Use `locals` when the expression:
+
+- Appears in more than one place.
+- Names a non-obvious invariant (`local.is_production = endswith(var.name, "-prod")`).
+- Flattens nested structures for `for_each` (common pattern).
+
+Don't use locals as tag-along variables for single-use intermediate values — just inline the expression.
+
+### Flattening example
+
+```hcl
+locals {
+  # Expand "one rule → many CIDR blocks" into "many atomic rules"
+  ingress_rule_cidrs = flatten([
+    for key, rule in var.ingress_rules : [
+      for cidr in rule.cidr_blocks : {
+        key  = "${key}-${cidr}"
+        rule = rule
+        cidr = cidr
+      }
+    ]
+  ])
+}
+
+resource "aws_vpc_security_group_ingress_rule" "default" {
+  for_each = { for r in local.ingress_rule_cidrs : r.key => r }
+  # …
+}
+```
+
+## Error surfaces
+
+Catch errors at the earliest layer:
+
+1. **Type system** — use `optional(...)` with defaults rather than `map(any)`.
+2. **Validation blocks** — enumerate valid values, require cross-field invariants.
+3. **Preconditions** — for invariants across resources/data sources.
+4. **Assertions in `terraform test`** — for derived/conditional logic.
+5. **Apply errors** — last resort; should be unreachable for configuration bugs.
+
+## Dependency graph hygiene
+
+- Prefer implicit dependencies via resource references.
+- Use `depends_on` only when the dependency cannot be expressed as a reference (e.g. IAM eventual consistency, CloudFormation stack existence).
+- Never use `depends_on` to paper over a missing resource reference.
+
+## Deprecated patterns to remove
+
+- `list("a", "b")` / `map("k", "v")` constructor functions → `["a", "b"]` / `{ k = "v" }` literals.
+- `aws_s3_bucket_object` → `aws_s3_object`.
+- Inline `aws_s3_bucket` sub-blocks (`versioning {}`, `lifecycle_rule {}`) → split resources (`aws_s3_bucket_versioning`, `aws_s3_bucket_lifecycle_configuration`).
+- `null_resource` → `terraform_data` (≥1.4).
+- `azurerm_function_app` → `azurerm_linux_function_app` / `azurerm_windows_function_app`.
+- `aws_lambda_permission` with `function_name = aws_lambda_function.x.function_name` where `.arn` is newer/clearer.

--- a/skills/terraform/references/code-patterns.md
+++ b/skills/terraform/references/code-patterns.md
@@ -28,7 +28,7 @@ resource "aws_s3_bucket" "default" {
   }
 
   # 6. Tags (always last data arg)
-  tags = local.tags
+  tags = var.tags
 
   # 7. Meta-blocks: lifecycle / depends_on
   lifecycle {
@@ -132,10 +132,13 @@ resource "azurerm_private_endpoint" "default" {
 
 ## Version management
 
+The exact floor number is not important — what matters is the **constraint shape**: floor-only for Terraform (no upper bound), and the correct presence or absence of an upper bound for each provider.
+
 ### In a module
 
-- `required_version = ">= 1.9"` — floor only, no upper bound.
-- Providers as `>= X.Y, < (X+1).0` — range with a major ceiling.
+- `required_version = ">= X.Y"` — floor only, no upper bound on Terraform itself.
+- Most providers: floor only (`>= X`), no upper bound.
+- Some providers require an upper bound at the next major (`>= X, < (X+1)`). Check the MCAF skill for which providers need this.
 - Never `= X.Y.Z` (exact) in a module.
 - Avoid `~> X.Y.Z` (patch-tight) — blocks patches.
 

--- a/skills/terraform/references/code-patterns.md
+++ b/skills/terraform/references/code-patterns.md
@@ -5,34 +5,64 @@
 
 ## Block ordering in a resource
 
+Empty lines separate each group. Within the third group, the identifier comes first, followed by alphabetically sorted other fields, then `tags`.
+
 ```hcl
 resource "aws_s3_bucket" "default" {
-  # 1. Meta-args
+  # 1. Meta-args: count / for_each (kept on top even when written as a block)
   for_each = var.buckets
 
-  # 2. Identifying args
-  bucket        = each.key
-  bucket_prefix = each.value.prefix
+  # 2. Meta-arg: provider
+  provider = aws.replica
 
-  # 3. Core config
-  force_destroy = each.value.force_destroy
-
-  # 4. Feature flags
+  # 3. region, identifier, alphabetically sorted other fields, then tags
+  bucket              = each.key
+  bucket_prefix       = each.value.prefix
+  force_destroy       = each.value.force_destroy
   object_lock_enabled = each.value.object_lock_mode != null
+  tags                = var.tags
 
-  # 5. Nested blocks
+  # 4. Nested blocks (each separated by empty lines)
   grant {
+    id          = each.value.owner_id
     permissions = ["FULL_CONTROL"]
     type        = "CanonicalUser"
-    id          = each.value.owner_id
   }
 
-  # 6. Tags (always last data arg)
-  tags = var.tags
-
-  # 7. Meta-blocks: lifecycle / depends_on
+  # 5. Meta-arg blocks: depends_on / lifecycle
   lifecycle {
     prevent_destroy = each.value.protected
+  }
+}
+```
+
+## Block ordering in a module
+
+Empty lines separate each group. Within the fourth group, the identifier comes first, followed by alphabetically sorted other fields, then `tags`.
+
+```hcl
+module "logging_bucket" {
+  # 1. Meta-args: count / for_each
+  for_each = var.buckets
+
+  # 2. Meta-args: source / version
+  source  = "schubergphilis/s3/aws"
+  version = "~> 1.0"
+
+  # 3. Meta-arg: providers
+  providers = {
+    aws = aws.replica
+  }
+
+  # 4. region, identifier, alphabetically sorted other fields, then tags
+  name          = each.key
+  force_destroy = each.value.force_destroy
+  versioning    = true
+  tags          = var.tags
+
+  # 5. Nested blocks (each separated by empty lines)
+  lifecycle {
+    prevent_destroy = true
   }
 }
 ```

--- a/skills/terraform/references/module-patterns.md
+++ b/skills/terraform/references/module-patterns.md
@@ -20,7 +20,7 @@
 | `main.tf` | Primary resources | |
 | `variables.tf` | All inputs with `type` + `description` | For large modules, split by domain: `variables.network.tf`, `variables.security.tf` |
 | `outputs.tf` | All outputs with `description` | |
-| `terraform.tf` | `required_version` + `required_providers` | Some codebases call this `versions.tf`; pick one and stick with it |
+| `terraform.tf` | `required_version` + `required_providers` | Some codebases call this `versions.tf`; pick `terraform.tf` |
 | `locals.tf` | Only if non-empty | |
 | `data.tf` | Only if non-empty | |
 | `README.md` | Prose + terraform-docs injection | |
@@ -132,29 +132,20 @@ Mark credential, token, kubeconfig, connection-string outputs `sensitive = true`
 
 ## Tags
 
-Centralise via locals:
+Reference `var.tags` directly on every taggable resource:
 
 ```hcl
-# locals.tf
-locals {
-  tags = merge(var.tags, {
-    ManagedBy = "Terraform"
-    Module    = "terraform-aws-mcaf-s3"  # optional but useful for provenance
-  })
-}
-
-# main.tf
 resource "aws_s3_bucket" "default" {
   # ...
-  tags = local.tags
+  tags = var.tags
 }
 ```
 
 Rules:
 
 - `variable "tags" { type = map(string); default = {} }`.
-- `local.tags = merge(var.tags, {...})`.
-- Reference `local.tags` on every taggable resource. Never hard-code a tag key inside a single resource block.
+- Reference `var.tags` on every taggable resource. No `local.tags` indirection unless the module genuinely needs to inject extra tags.
+- Never hard-code a tag key inside a single resource block.
 - Skip `try(var.tags, {})` — useless when the var has a default.
 
 ## Resource argument ordering inside a block
@@ -164,7 +155,7 @@ Rules:
 3. Core config: sku, type, tier, sizes, encryption.
 4. Feature flags (booleans).
 5. Nested blocks.
-6. `tags = local.tags` (always last before closing brace).
+6. `tags = var.tags` (always last before closing brace).
 7. `lifecycle {}` / `depends_on` (meta-blocks last).
 
 ## Resource labels

--- a/skills/terraform/references/module-patterns.md
+++ b/skills/terraform/references/module-patterns.md
@@ -150,13 +150,24 @@ Rules:
 
 ## Resource argument ordering inside a block
 
-1. Meta-args: `provider`, `for_each`, `count`.
-2. Identifying args: `name`, `resource_group_name`, `bucket`, `location`.
-3. Core config: sku, type, tier, sizes, encryption.
-4. Feature flags (booleans).
-5. Nested blocks.
-6. `tags = var.tags` (always last before closing brace).
-7. `lifecycle {}` / `depends_on` (meta-blocks last).
+Empty lines separate each group:
+
+1. `count` / `for_each` — meta-args first; even when written as a block, keep on top.
+2. `provider`.
+3. `region`, identifier (`name`, `bucket`, `resource_group_name`, `location`, …), then **alphabetically sorted** other fields, then `tags`.
+4. Nested blocks (each separated by empty lines).
+5. Meta-argument blocks: `depends_on`, `lifecycle`.
+
+## Module argument ordering inside a block
+
+Empty lines separate each group:
+
+1. `count` / `for_each`.
+2. `source`, `version`.
+3. `providers`.
+4. `region`, identifier (`name`, …), then **alphabetically sorted** other fields, then `tags`.
+5. Nested blocks (each separated by empty lines).
+6. Meta-argument blocks: `depends_on`, `lifecycle`.
 
 ## Resource labels
 

--- a/skills/terraform/references/module-patterns.md
+++ b/skills/terraform/references/module-patterns.md
@@ -1,0 +1,257 @@
+# Module patterns
+
+> Part of: [`terraform`](../SKILL.md) skill.
+> Purpose: module design and layout best practices.
+
+## Module hierarchy
+
+| Type | When | Scope |
+|---|---|---|
+| **Resource module** | One logical group of connected resources | VPC + subnets; S3 bucket + policy + encryption |
+| **Infrastructure module** | Several resource modules for one purpose | Landing zone for one account |
+| **Composition** | Whole deployments, possibly multi-region/account | Org-wide infra |
+
+**Build bottom-up.** Inlining across levels (e.g. a resource module that also creates IAM policies for ten other modules) couples everything and blocks reuse.
+
+## Root files
+
+| File | Purpose | Notes |
+|---|---|---|
+| `main.tf` | Primary resources | |
+| `variables.tf` | All inputs with `type` + `description` | For large modules, split by domain: `variables.network.tf`, `variables.security.tf` |
+| `outputs.tf` | All outputs with `description` | |
+| `terraform.tf` | `required_version` + `required_providers` | Some codebases call this `versions.tf`; pick one and stick with it |
+| `locals.tf` | Only if non-empty | |
+| `data.tf` | Only if non-empty | |
+| `README.md` | Prose + terraform-docs injection | |
+| `CHANGELOG.md` | Release history | |
+| `LICENSE` | Usually Apache-2.0 for OSS | |
+
+## Variables
+
+### Arg order inside a variable block
+
+```hcl
+variable "x" {
+  type        = …       # 1. type first
+  default     = …       # 2. default (if present)
+  description = "…"     # 3. description (always)
+  nullable    = false   # 4. nullable (if non-default)
+  sensitive   = true    # 5. sensitive (if non-default)
+  validation { … }      # 6. validation(s) last
+}
+```
+
+This order reads well and keeps blocks consistent.
+
+### Typed objects vs flat variables
+
+Prefer complex typed objects:
+
+```hcl
+variable "backup" {
+  type = object({
+    enabled         = optional(bool, false)
+    retention_days  = optional(number, 30)
+    storage_account = optional(string)
+  })
+  default     = {}
+  description = "Backup configuration."
+}
+```
+
+over:
+
+```hcl
+variable "backup_enabled"        { type = bool   default = false }
+variable "backup_retention_days" { type = number default = 30 }
+variable "backup_storage_account"{ type = string default = null }
+```
+
+The typed object:
+
+- Keeps caller invocation terse (`backup = { enabled = true }`).
+- Makes invariants expressible in validation.
+- Scales without variable sprawl.
+
+### Validation
+
+Write `validation` for:
+
+- Enumerated values (`contains([...], var.x)`).
+- Regex-matching (`can(regex("^…$", var.x))`).
+- Cross-field invariants (`var.a != null ? var.b != null : true`).
+- Ranges (`var.days >= 7 && var.days <= 30`).
+
+Always give `error_message` a concrete, actionable hint — not just "invalid value".
+
+### Nullable and sensitive
+
+- `nullable = false` when `null` is not a meaningful value. Defaults to `true` which silently admits `null`.
+- `sensitive = true` on any secret (API key, password, token, private key). Blocks plan output leakage.
+- `default = null` over `default = ""` for "not provided" — lets `var.x == null` work correctly.
+
+### Naming
+
+- `snake_case` everywhere: variable names, output names, local names, resource labels.
+- Booleans as statements: `versioning`, `force_destroy`, `bucket_key_encryption_enforced`. Avoid `enable_` / `disable_` prefixes.
+- No module-name prefix: in `terraform-aws-mcaf-s3` the variable is `versioning`, not `s3_versioning`.
+- No redundant compound outputs: `arn`, not `bucket_arn`.
+
+## Outputs
+
+### Ordering
+
+`id`, `arn`, `name` first (whichever apply to the provider), then outputs ordered by downstream usefulness — not alphabetical.
+
+### Minimum useful surface
+
+Expose the attributes callers actually need. Resist the urge to re-export the whole resource. A common failure mode is:
+
+```hcl
+# BAD — leaks everything, including sensitive fields
+output "resource" {
+  value = aws_kubernetes_cluster.this
+}
+```
+
+Instead:
+
+```hcl
+output "id"   { value = aws_kubernetes_cluster.this.id }
+output "name" { value = aws_kubernetes_cluster.this.name }
+output "kube_config" {
+  value     = aws_kubernetes_cluster.this.kube_config
+  sensitive = true
+}
+```
+
+### Sensitive outputs
+
+Mark credential, token, kubeconfig, connection-string outputs `sensitive = true`. Without it, `terraform plan` prints the value.
+
+## Tags
+
+Centralise via locals:
+
+```hcl
+# locals.tf
+locals {
+  tags = merge(var.tags, {
+    ManagedBy = "Terraform"
+    Module    = "terraform-aws-mcaf-s3"  # optional but useful for provenance
+  })
+}
+
+# main.tf
+resource "aws_s3_bucket" "default" {
+  # ...
+  tags = local.tags
+}
+```
+
+Rules:
+
+- `variable "tags" { type = map(string); default = {} }`.
+- `local.tags = merge(var.tags, {...})`.
+- Reference `local.tags` on every taggable resource. Never hard-code a tag key inside a single resource block.
+- Skip `try(var.tags, {})` — useless when the var has a default.
+
+## Resource argument ordering inside a block
+
+1. Meta-args: `provider`, `for_each`, `count`.
+2. Identifying args: `name`, `resource_group_name`, `bucket`, `location`.
+3. Core config: sku, type, tier, sizes, encryption.
+4. Feature flags (booleans).
+5. Nested blocks.
+6. `tags = local.tags` (always last before closing brace).
+7. `lifecycle {}` / `depends_on` (meta-blocks last).
+
+## Resource labels
+
+- Single instance of a resource type in a module → use a canonical label. Common conventions: `"default"` (used by AWS community + anton-babenko style), `"this"` (used by azurerm community).
+- **Pick one per organisation and stick with it.** Mixing `"default"` and `"this"` in one repo is noise.
+- For additional instances of the same resource type: use a descriptive label (`"logging"`, `"replica"`, `"cmk"`), not `"default2"`.
+- With `for_each`/`count`, keep the canonical single label — multiplicity is expressed by the meta-arg.
+
+## Multi-provider orchestration
+
+If a module legitimately needs two providers (e.g. AWS S3 replication between accounts):
+
+```hcl
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = ">= 6.0, < 7.0"
+      configuration_aliases = [aws.source, aws.destination]
+    }
+  }
+}
+```
+
+Callers then pass both providers:
+
+```hcl
+module "s3_repl" {
+  source = "…"
+  providers = {
+    aws.source      = aws.us_east_1
+    aws.destination = aws.eu_west_1
+  }
+}
+```
+
+Never put `provider "aws" { region = "…" }` inside a reusable module. Provider configuration is the caller's responsibility.
+
+## README
+
+```markdown
+# <repo-name>
+
+<one-line purpose>
+
+IMPORTANT: We do not pin modules to versions in our examples. Pin in your own code
+so that your infrastructure remains stable.
+
+## <prose sections for non-obvious behaviour — gotchas, security notes, caveats>
+
+<!-- BEGIN_TF_DOCS -->
+<!-- injected by terraform-docs via CI; DO NOT EDIT -->
+<!-- END_TF_DOCS -->
+
+## Licensing
+
+Apache-2.0. See [LICENSE](LICENSE).
+```
+
+- First H1 = repo name.
+- Prose sections above the `BEGIN_TF_DOCS` / `END_TF_DOCS` markers, not inside.
+- No hand-written `## Usage` blocks with HCL snippets — they rot. Point people to `examples/` instead.
+- End with `## Licensing`.
+
+## Anti-patterns to avoid
+
+- Whole-resource outputs (`output "resource" { value = aws_x.this }`) — leak everything.
+- Hard-pinned child-module refs (`source = "git::…?ref=v1.2.3"`) inside a reusable module. Propagates version debt outward.
+- Two sources of truth for the same field (`var.name` and `var.config.name`).
+- Creating a resource group / VPC inside a resource module — caller should own shared infrastructure.
+- `provider "aws" { … }` blocks inside a reusable module.
+- `try(var.tags, {})` cargo-culted around variables with a default.
+- `default = null` on a genuinely required input — contradicts the description.
+- Empty `outputs.tf`.
+- Missing `sensitive = true` on secrets.
+- Floating `:latest` / `:main` image/version defaults — non-idempotent.
+- Dead variables, locals, commented-out resources.
+- File-naming drift (camelCase, `backend.tf` / `module.tf` misuse).
+- Nested ternaries in variable bodies that `optional(field, default)` would eliminate.
+- `null_resource` or deprecated resources (`aws_s3_bucket_object`, `azurerm_function_app`) in new code.
+
+## Examples directory
+
+Every module must have `examples/default/`. Add additional `examples/<scenario>/` per major feature branch. Rules:
+
+- Each example is runnable (`terraform init && terraform validate` passes).
+- Examples reference the module via relative source (`source = "../../"`) — no `version = …`.
+- Each example is linted in CI.
+- CI runs `terraform validate` and optionally `tflint` per example.

--- a/skills/terraform/references/quick-reference.md
+++ b/skills/terraform/references/quick-reference.md
@@ -1,0 +1,240 @@
+# Quick reference
+
+> Part of: [`terraform`](../SKILL.md) skill.
+> Purpose: cheat sheets for rapid consultation.
+
+## Command cheat sheet
+
+Works with both `terraform` and `tofu`.
+
+```bash
+# Format + lint
+terraform fmt -check -recursive
+tflint --format compact
+tflint --chdir=examples/default
+
+# Validate + plan per example
+for d in examples/*/; do
+  terraform -chdir="$d" init -backend=false
+  terraform -chdir="$d" validate -no-color
+done
+
+# Native tests
+terraform init                   # fetch providers
+terraform test                   # run all .tftest.hcl
+terraform test -verbose
+terraform test -filter=tests/main.tftest.hcl
+
+# Pre-commit
+pre-commit install                # install git hook
+pre-commit run -a                 # run all hooks on all files
+
+# Docs
+terraform-docs . --sort-by required
+terraform-docs . --output-file README.md --output-method inject
+
+# Security
+checkov -d .
+trivy config .
+
+# State
+terraform state list
+terraform state show <addr>
+terraform state mv <from> <to>
+terraform state rm <addr>
+
+# Migrations
+# Prefer `moved {}` blocks over `terraform state mv` for reproducibility.
+```
+
+## Decision flowchart
+
+```
+Start: new module
+├── Is it a single resource group (VPC, bucket, cluster)?
+│   └── Resource module
+├── Is it a set of resource modules for one purpose?
+│   └── Infrastructure module (calls resource modules)
+└── Is it an entire environment/account?
+    └── Composition (calls infrastructure modules)
+
+Start: new variable
+├── Is the value genuinely optional or has a sensible default?
+│   └── default = <something>
+├── Is null a meaningful input?
+│   └── default = null
+├── Is null NOT meaningful?
+│   └── nullable = false (no default, required)
+├── Is it a secret?
+│   └── sensitive = true
+├── Are valid values enumerable?
+│   └── validation { condition = contains([...], var.x) }
+└── Has cross-field invariants?
+    └── validation { condition = … complex … }
+
+Start: new resource field
+├── Same for all calls?
+│   └── Hard-code
+├── Differs per call, N possible values?
+│   └── variable with validation
+├── Differs per call, derived from another variable?
+│   └── local
+└── Differs per caller, complex shape?
+    └── typed object variable with optional(…)
+
+Start: multiplicity
+├── One instance, always?
+│   └── No count/for_each
+├── One or zero?
+│   └── count = var.enabled ? 1 : 0
+├── Stable keys, known at plan time?
+│   └── for_each = toset(var.items) or for_each = var.objects
+└── Positional, order-sensitive?
+    └── count = length(…) — rare, prefer for_each
+```
+
+## Version-specific guidance
+
+| Version | Features |
+|---|---|
+| 0.12 | HCL 2, `for`/`dynamic` — floor for anything current. |
+| 0.13 | Provider source addresses in `required_providers`. |
+| 1.0 | Stability guarantee; safe floor. |
+| 1.1 | `moved {}` blocks. |
+| 1.2 | `precondition` / `postcondition`. |
+| 1.3 | `optional(field, default)` in object types. |
+| 1.4 | `terraform_data` replaces `null_resource`. |
+| 1.5 | `check {}` blocks; `import {}` block. |
+| 1.6 | Native `terraform test` (alpha ≥1.6, mature ≥1.7). |
+| 1.7 | `removed {}` block for intentional un-management. |
+| 1.8 | Provider functions (`provider::<ns>::<fn>()`). |
+| 1.9+ | Modern baseline — recommended floor for new code. |
+
+If your module is still on `>= 0.13`, you're blocked from every feature above it. Bump on next touch.
+
+## Troubleshooting
+
+### `terraform validate` passes but `terraform plan` errors
+
+Usually a reference to an attribute that doesn't exist on the resource you referenced (most common: `.id` vs `.name` vs `.arn`). `validate` doesn't evaluate expressions that depend on actual resource schemas.
+
+### `for_each` producing "may only be given a map or a set of strings"
+
+You have `for_each = var.x` where `var.x` is `list(string)`. Convert with `toset(var.x)`.
+
+### "Cycle" errors
+
+Two resources / modules reference each other. Usually solved by:
+
+- Splitting the offending attribute into a data source.
+- Using `depends_on` where a reference can't work.
+- Extracting a shared local that both consume (breaks the cycle in the graph).
+
+### `mock_provider` in tests is returning `null` for fields I mocked
+
+Did you use `mock_data` for a data source (correct) where the resource is actually a resource? Use `mock_resource` (provider-level) or `override_resource` (run-level) instead.
+
+### Provider version conflict on `terraform init`
+
+Multiple child modules demand incompatible version ranges. Look at the union in `terraform providers`. Often fixed by widening one module's range to include the other's.
+
+### `moved {}` block ignored
+
+`moved` only works within the same module. Cross-module moves need `terraform state mv` or a refactor that routes state through the correct module boundary.
+
+## Migration paths
+
+### From `count` to `for_each`
+
+```hcl
+# Before
+resource "aws_s3_bucket" "default" { bucket = var.name }
+
+# After
+resource "aws_s3_bucket" "default" {
+  for_each = toset([var.name])
+  bucket   = each.value
+}
+
+moved {
+  from = aws_s3_bucket.default
+  to   = aws_s3_bucket.default[var.name]
+}
+```
+
+### From `versions.tf` to `terraform.tf`
+
+```bash
+git mv versions.tf terraform.tf
+# commit + push
+```
+
+Pure rename; CI picks it up. No state change.
+
+### From deprecated `aws_s3_bucket_object` to `aws_s3_object`
+
+```hcl
+resource "aws_s3_object" "default" { … }
+
+moved {
+  from = aws_s3_bucket_object.default
+  to   = aws_s3_object.default
+}
+```
+
+### From `null_resource` to `terraform_data`
+
+```hcl
+resource "terraform_data" "default" {
+  triggers_replace = [var.version]
+}
+
+moved {
+  from = null_resource.default
+  to   = terraform_data.default
+}
+```
+
+Requires `required_version = ">= 1.4"`.
+
+## Common `validation` patterns
+
+```hcl
+# Enumerated
+validation {
+  condition     = contains(["small", "medium", "large"], var.size)
+  error_message = "size must be small, medium, or large."
+}
+
+# Regex (name prefix, CIDR, ARN shape)
+validation {
+  condition     = can(regex("^[a-z0-9-]+$", var.name))
+  error_message = "name must be lowercase letters, digits, and hyphens only."
+}
+
+# Cross-field
+validation {
+  condition     = var.name == null || var.name_prefix == null
+  error_message = "Specify name or name_prefix, not both."
+}
+
+# List non-empty
+validation {
+  condition     = length(var.ids) > 0
+  error_message = "At least one id is required."
+}
+
+# Numeric range
+validation {
+  condition     = var.retention_days >= 7 && var.retention_days <= 35
+  error_message = "retention_days must be between 7 and 35."
+}
+
+# Nested object invariant
+validation {
+  condition = alltrue([
+    for r in var.rules : r.from_port <= r.to_port
+  ])
+  error_message = "Each rule must have from_port ≤ to_port."
+}
+```

--- a/skills/terraform/references/security-compliance.md
+++ b/skills/terraform/references/security-compliance.md
@@ -1,0 +1,146 @@
+# Security and compliance
+
+> Part of: [`terraform`](../SKILL.md) skill.
+> Purpose: scanning, secrets, state, and compliance patterns.
+
+## Scanners
+
+Run at least one static security scanner in pre-commit and in CI. Common choices:
+
+| Tool | Strengths | Notes |
+|---|---|---|
+| **Checkov** | Broad coverage (Terraform, CFN, K8s, Dockerfile). SARIF output. | De-facto standard. |
+| **tfsec** | Fast, Terraform-focused. | Now largely merged into Trivy. |
+| **Trivy** | One tool for Terraform + containers + filesystems. | Good if you already use it for container scanning. |
+| **terrascan** | Policy-as-code via Rego. | Useful when you have OPA experience. |
+
+Pick one and run it in both pre-commit and CI. Running two is usually duplicative.
+
+## Suppressing findings
+
+Suppress individual rules only with an inline comment citing the reason:
+
+```hcl
+# checkov:skip=CKV_AWS_18:Logging is centralised at the account level.
+resource "aws_s3_bucket" "default" {
+  # ...
+}
+```
+
+Rules:
+
+- Always give a human-readable reason, not just the rule ID.
+- Review the suppression when the module changes (does the reason still hold?).
+- Never suppress at the repo level with a blanket exclusion.
+
+## Common security issues in modules
+
+- **Public S3/blob storage by default.** Default to private; require explicit opt-in for public.
+- **Unencrypted storage.** Default to encrypted; most providers require KMS/CMK for compliance anyway.
+- **Wide-open security groups / NSGs.** `0.0.0.0/0` on inbound is almost never the right default.
+- **Missing logging.** CloudTrail, VPC flow logs, storage-account diagnostic settings — enable by default.
+- **Long-lived access keys.** Prefer OIDC/IAM Roles over access keys. Mark any access key output `sensitive`.
+- **TLS < 1.2.** Default to TLS 1.2 minimum; expose knob only to explicitly relax.
+- **Missing deletion protection.** RDS, DynamoDB, EKS — callers expect these to be protected by default.
+
+## Secrets handling
+
+### Modules must not accept plaintext secrets
+
+```hcl
+# BAD
+variable "api_key" {
+  type = string
+}
+
+# BETTER
+variable "api_key_secret_arn" {
+  type        = string
+  description = "ARN of a Secrets Manager secret holding the API key."
+}
+```
+
+The caller stores the secret in the secret manager; the module fetches via a data source if it actually needs the value, or just passes the ARN.
+
+### If you must take a plaintext secret
+
+```hcl
+variable "api_key" {
+  type      = string
+  sensitive = true
+}
+```
+
+- Always `sensitive = true`.
+- Default to `null`, not `""`.
+- Never log / format / `base64encode` it to stdout.
+- Never include it in an output unless the output is also `sensitive = true`.
+
+### Generating secrets in the module
+
+`random_password` is fine for module-generated secrets. Store the result in a secret manager immediately — don't leave it in Terraform state as the primary source:
+
+```hcl
+resource "random_password" "db" {
+  length  = 32
+  special = true
+}
+
+resource "aws_secretsmanager_secret_version" "db" {
+  secret_id     = aws_secretsmanager_secret.db.id
+  secret_string = random_password.db.result
+}
+```
+
+## State security
+
+- **Remote backend** with state locking (`dynamodb_table` for S3 backend, Azure Storage account with lease-based lock, GCS bucket, or HCP Terraform workspace).
+- **Encrypt at rest.** S3 bucket SSE, GCS with CMEK, Azure Storage with CMK.
+- **Restrict access.** The state bucket/store has IAM more privileged than anyone else — treat it like a secret vault.
+- **Never commit state files.** Add `*.tfstate*` to `.gitignore`.
+- **State drift detection.** Scheduled `terraform plan` runs that alert on drift.
+
+## Provider version pinning as a security practice
+
+- Patch updates to providers often fix security issues. **Floor-with-range** (`>= 6.0, < 7.0`) lets callers pick up patches automatically.
+- **Exact pinning** (`= 6.1.2`) in a module blocks callers from getting security fixes.
+- **Floating major-ceiling** (`>= 6.0`) accepts breaking-change releases unreviewed — mildly dangerous.
+
+## Supply-chain hygiene for modules
+
+- Don't vendor upstream modules. Reference via `schubergphilis/<name>/<provider>` (registry) + a `version = "~> X.Y"` range.
+- Never use `source = "github.com/.../repo?ref=<branch>"` — mutable.
+- Never use `source = "git::https://.../repo.git"` without a `ref=<tag or SHA>`.
+- Lambda code shipped with a module: pin Python `requirements.txt` (`==X.Y.Z`), commit a lockfile for Node (`package-lock.json` / `yarn.lock` / `pnpm-lock.yaml`).
+- Action pins: SHA > exact tag > minor > major > never branch (`@main` / `@master`).
+
+## Compliance automation
+
+If you need to prove a control to an auditor:
+
+1. Encode the control as a `validation` or `precondition` block — fail at plan time.
+2. Back it with a checkov custom rule that scans for the same pattern — catches it in CI.
+3. Document the control ID in a comment next to the check, so the evidence chain is traceable.
+
+Example:
+
+```hcl
+resource "aws_s3_bucket_public_access_block" "default" {
+  # Security Hub: S3.1 — S3 general purpose buckets should have block public access settings enabled
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+  # ...
+}
+```
+
+## Defence in depth
+
+A module-level check is cheap but not complete. Pair with:
+
+- Account-level preventive controls (SCPs, Azure Policy).
+- Runtime detective controls (CloudTrail, Defender for Cloud, Datadog).
+- Regular audit cadence, not just per-PR scans.
+
+Treat module-level checks as the first line, not the only line.

--- a/skills/terraform/references/security-compliance.md
+++ b/skills/terraform/references/security-compliance.md
@@ -102,9 +102,10 @@ resource "aws_secretsmanager_secret_version" "db" {
 
 ## Provider version pinning as a security practice
 
-- Patch updates to providers often fix security issues. **Floor-with-range** (`>= 6.0, < 7.0`) lets callers pick up patches automatically.
+- Patch updates to providers often fix security issues. A floor-only constraint (`>= 6`) lets callers pick up patches automatically.
+- Some providers (e.g. Azurerm, Datadog) need an upper bound at the next major to avoid unreviewed breaking changes.
 - **Exact pinning** (`= 6.1.2`) in a module blocks callers from getting security fixes.
-- **Floating major-ceiling** (`>= 6.0`) accepts breaking-change releases unreviewed — mildly dangerous.
+- The exact floor number is not important — focus on the constraint shape (floor-only vs floor + ceiling).
 
 ## Supply-chain hygiene for modules
 

--- a/skills/terraform/references/testing.md
+++ b/skills/terraform/references/testing.md
@@ -1,0 +1,206 @@
+# Testing
+
+> Part of: [`terraform`](../SKILL.md) skill.
+> Purpose: testing approach decision matrix and patterns.
+
+## The pyramid
+
+Do these in order. Each catches different classes of issues and costs more than the last.
+
+| Layer | Tool | Cost | Catches |
+|---|---|---|---|
+| 1. Format | `terraform fmt -check -recursive` | free | formatting drift |
+| 2. Lint | `tflint` | free | provider-specific mistakes, naming |
+| 3. Static validation | `terraform validate` | free | syntax, type mismatches |
+| 4. Security scan | `checkov` / `tfsec` / `trivy` | free | insecure defaults |
+| 5. Plan test | `terraform plan` on every example | free | missing inputs, graph errors |
+| 6. Native test | `terraform test` with `mock_provider` | free | derived logic, validation branches |
+| 7. Apply test | Terratest, `terraform apply` in sandbox | cost | real infrastructure integration |
+
+Ship layers 1–6 on every PR. Layer 7 only when you actually need to verify real cloud behaviour.
+
+## Layer 1-4: pre-commit + CI
+
+Ship a `.pre-commit-config.yaml`:
+
+```yaml
+default_stages: [pre-commit]
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-json
+      - id: check-merge-conflict
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: detect-aws-credentials
+        args: [--allow-missing-credentials]
+      - id: detect-private-key
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.98.1
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_tflint
+      - id: terraform_docs
+      - id: terraform_validate
+  - repo: https://github.com/bridgecrewio/checkov.git
+    rev: 3.2.388
+    hooks:
+      - id: checkov
+        args: [--quiet, --compact, --skip-path, "examples/*"]
+```
+
+Run the same tools in CI. No exceptions that are only in local. No exceptions that are only in CI.
+
+## Layer 5: plan test per example
+
+CI step that validates every example can plan:
+
+```yaml
+- name: Terraform validate examples
+  run: |
+    for d in examples/*/; do
+      echo "Validating ${d}"
+      terraform -chdir="$d" init -backend=false
+      terraform -chdir="$d" validate -no-color
+    done
+```
+
+If an example has provider credentials available, run `terraform plan` too — catches reference errors.
+
+## Layer 6: native `terraform test`
+
+Live under `tests/`:
+
+```
+tests/
+├── main.tftest.hcl
+└── setup/
+    └── main.tf          # optional fixture module
+```
+
+Basic shape:
+
+```hcl
+# tests/main.tftest.hcl
+
+mock_provider "aws" {
+  mock_data "aws_region" {
+    defaults = { region = "eu-central-1" }
+  }
+}
+
+run "setup" {
+  module { source = "./tests/setup" }
+}
+
+run "default" {
+  command = plan
+  module  { source = "./" }
+
+  assert {
+    condition     = aws_s3_bucket.default.bucket != null
+    error_message = "Expected a bucket to be planned."
+  }
+}
+
+run "invalid_input_is_rejected" {
+  command = plan
+
+  variables {
+    mode = "not_a_valid_mode"
+  }
+
+  expect_failures = [var.mode]
+}
+```
+
+Patterns:
+
+- **Always start with `mock_provider`** so tests run without cloud credentials.
+- **One `run` per behaviour**: `default`, `with_logging`, `invalid_foo`.
+- **Assert on derived values**, not fields equal to the input variable. Testing `bucket.name == var.name` is a tautology.
+- **Use `expect_failures`** for negative paths — checks the validation fires, doesn't just swallow the apply error.
+- **Use `override_data`** to mock expensive policy documents:
+  ```hcl
+  run "default" {
+    override_data {
+      target = data.aws_iam_policy_document.combined
+      values = { json = "{\"fake\":true}" }
+    }
+    # …
+  }
+  ```
+- **Fixtures in `tests/setup/`** for things multiple `run` blocks need (mock VPCs, buckets, etc.).
+
+## Layer 7: Terratest (only when necessary)
+
+Reach for Terratest (Go) only when:
+
+- You need to assert on real cloud behaviour that a mock cannot simulate (e.g. TLS handshake, HTTP behaviour).
+- The module has tricky post-apply behaviour (data sources that only resolve after create).
+- You're testing a composition, not a resource module.
+
+Cost: requires Go toolchain, real credentials, often ~10 minutes per run vs seconds for native tests. Every Terratest is a maintenance burden.
+
+Native `terraform test` with `mock_provider` replaces ~90% of what Terratest used to be used for.
+
+## What to actually test
+
+**Do test:**
+
+- Conditional resource creation (`count = var.x ? 1 : 0`).
+- Derived values in locals (`local.name = coalesce(var.override, var.name)`).
+- Every `validation` block fires on invalid inputs.
+- Cross-field invariants expressed in `precondition`.
+- `for_each` expansion for edge cases (empty map, single entry, many entries).
+- Sensitive output wiring (smoke test, not the value).
+
+**Don't test:**
+
+- Terraform itself (`aws_s3_bucket.default.bucket == var.name`).
+- Provider behaviour (`terraform test` won't catch AWS API bugs).
+- Upstream module internals.
+- Things already covered by `validation` — the validation IS the test.
+
+## Examples as tests
+
+Keep every example runnable against a real cloud. They serve triple duty:
+
+1. Documentation.
+2. Smoke tests in CI (`terraform validate`).
+3. Optional `terraform plan` in PR (if cloud credentials available).
+
+Put realistic inputs in examples. `examples/default/main.tf` that passes zero variables does not demonstrate anything useful.
+
+## Test naming
+
+- File: `tests/main.tftest.hcl` plus one file per major scenario.
+- `run` block names: short, describe the branch (`default`, `with_encryption`, `public_access_blocked`, `invalid_region`).
+- No `run "test_1"`, `run "basic_test_2"` — the name describes behaviour, not index.
+
+## Debugging a failing test
+
+```bash
+# Full output
+terraform test -verbose
+
+# Just one run block
+terraform test -filter=tests/main.tftest.hcl -filter='run.with_encryption'
+```
+
+If the failure is about a mocked resource field returning `null`:
+
+- `mock_data` for data sources.
+- `mock_resource` for resources (provider-level default).
+- `override_data` / `override_resource` inside a `run` block (test-level overrides).
+
+## Parallel test hazards
+
+Native tests run sequentially by default. If you use `parallel` settings, watch out for:
+
+- Shared `mock_provider` state mutations.
+- Fixture modules creating resources that another `run` depends on.
+
+Safer: keep `run` blocks independent, each with its own `module { source = "./" }` call.

--- a/skills/terraform/references/testing.md
+++ b/skills/terraform/references/testing.md
@@ -21,35 +21,7 @@ Ship layers 1–6 on every PR. Layer 7 only when you actually need to verify rea
 
 ## Layer 1-4: pre-commit + CI
 
-Ship a `.pre-commit-config.yaml`:
-
-```yaml
-default_stages: [pre-commit]
-repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
-    hooks:
-      - id: check-json
-      - id: check-merge-conflict
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-yaml
-      - id: detect-aws-credentials
-        args: [--allow-missing-credentials]
-      - id: detect-private-key
-  - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.98.1
-    hooks:
-      - id: terraform_fmt
-      - id: terraform_tflint
-      - id: terraform_docs
-      - id: terraform_validate
-  - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 3.2.388
-    hooks:
-      - id: checkov
-        args: [--quiet, --compact, --skip-path, "examples/*"]
-```
+Ship a `.pre-commit-config.yaml` with hooks for formatting, linting, validation, docs generation, and security scanning (e.g. checkov). The canonical config is maintained in [`mcaf-github-workflows/sync-root/.pre-commit-config.yaml`](https://github.com/schubergphilis/mcaf-github-workflows/blob/main/sync-root/.pre-commit-config.yaml) — read the repository's copy for exact hooks and versions.
 
 Run the same tools in CI. No exceptions that are only in local. No exceptions that are only in CI.
 


### PR DESCRIPTION
## Summary

- Adds a `terraform` pack that auto-activates on `*.tf` / `terraform.tf` / `versions.tf` — a tight <300-word AGENTS.md fragment covering layout, version ranges, variable/output design, `local.tags`, testing, and state/secrets hygiene.
- Imports three opt-in skills from the `mcaf-review` repo: `terraform` (generic Terraform/OpenTofu baseline with a `references/` set), `mcaf-module` (Schuberg Philis MCAF deltas, bundling `GUIDE.md` — the authoritative way-of-working distilled from the 91-module corpus), and `review-mcaf` (qualitative good/bad/verdict review, parallelised across many modules).
- Ships `scripts/sync-terraform-skills.sh` — one-command, idempotent sync from `mcaf-review` into this repo while the skills are still under active iteration. Rewrites cross-skill `GUIDE.md` path references so the links resolve once skills are symlinked as siblings under `~/.claude/skills/`. `--check` for dry-run.
- Documents the three-layer design (pack → terraform → mcaf-module → review-mcaf), common workflows, and the source-of-truth rule in a new README section.

## Test plan

- [x] `python3 cli/sbp-skills validate packs/terraform skills/terraform skills/mcaf-module skills/review-mcaf` passes.
- [x] `python3 -m pytest tests/ -q` — 52 tests pass.
- [x] `python3 cli/sbp-skills list` shows the new pack and three skills.
- [x] `scripts/sync-terraform-skills.sh` runs cleanly, `--check` reports only intentional path-rewrite drift, and a second sync is idempotent.
- [x] AGENTS.md word count under the 300-word cap (276).
- [x] Reviewer: verify the README "Terraform & MCAF" section answers how to use each layer and how to keep content in sync with `mcaf-review`.