### PR TITLE
feat: respect CLAUDE_CONFIG_DIR env var for Claude config path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,12 +15,12 @@
       "source": "./",
       "strict": false,
       "skills": [
-        "./skills/architecture-review",
-        "./skills/deploy-checklist",
-        "./skills/incident-review",
-        "./skills/observability-check",
-        "./skills/runbook-author",
-        "./skills/safe-change"
+        "./skills/sbp-architecture-review",
+        "./skills/sbp-deploy-checklist",
+        "./skills/sbp-incident-review",
+        "./skills/sbp-observability-check",
+        "./skills/sbp-runbook-author",
+        "./skills/sbp-safe-change"
       ]
     },
     {
@@ -29,9 +29,9 @@
       "source": "./",
       "strict": false,
       "skills": [
-        "./skills/threat-model",
-        "./skills/secure-code-review",
-        "./skills/dependency-audit"
+        "./skills/sbp-threat-model",
+        "./skills/sbp-secure-code-review",
+        "./skills/sbp-dependency-audit"
       ]
     },
     {
@@ -40,14 +40,14 @@
       "source": "./",
       "strict": false,
       "skills": [
-        "./skills/explain-codebase",
-        "./skills/agent-architecture-review",
-        "./skills/why-we-do-this",
-        "./skills/feature-development",
-        "./skills/debug-investigation",
-        "./skills/refactor",
-        "./skills/test-planning",
-        "./skills/test-authoring"
+        "./skills/sbp-explain-codebase",
+        "./skills/sbp-agent-architecture-review",
+        "./skills/sbp-why-we-do-this",
+        "./skills/sbp-feature-development",
+        "./skills/sbp-debug-investigation",
+        "./skills/sbp-refactor",
+        "./skills/sbp-test-planning",
+        "./skills/sbp-test-authoring"
       ]
     },
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,12 @@ python3 -m pytest tests/test_fragment.py::test_insert_baseline -v
 
 Single-file Python CLI at `cli/sbp-skills` (stdlib only, Python 3.11+). Content lives in `baseline/`, `packs/`, `skills/`. Tests import the CLI via importlib in `tests/conftest.py`.
 
+## Git workflow
+
+- Always create a feature branch before making commits — never commit directly to `main`
+- Branch naming: `feat/<topic>`, `fix/<topic>`, `chore/<topic>`
+- Open a PR after committing; do not push to main directly
+
 ## Key conventions
 
 - CLI must use only Python standard library — no pip dependencies

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -1,0 +1,114 @@
+# How to use sbp-skills
+
+This guide shows how sbp-skills changes your daily work in Claude Code. It assumes you already use Claude Code and know what a skill is. The examples follow one scenario throughout: building an alerting pipeline for a mission-critical service.
+
+---
+
+## 1. Install
+
+Open Claude Code and run:
+
+```
+/plugin marketplace add schubergphilis/agents.md
+```
+
+Then install the skill groups you want:
+
+```
+/plugin install operations-skills@sbp-skills
+/plugin install security-skills@sbp-skills
+/plugin install engineering-skills@sbp-skills
+/plugin install brand-skills@sbp-skills
+```
+
+To verify it worked, ask Claude: *"What should I think about before adding a new service to our platform?"*
+
+Without sbp-skills, you get a generic answer. With it, Claude asks about blast radius, rollback, who gets paged, and what happens at 3 AM. That difference is the point.
+
+---
+
+## 2. Plan: Designing a new system
+
+**Context:** Your team needs a real-time alerting pipeline. Before writing a line of code, you want to think through the architecture.
+
+```
+Use sbp-architecture-review to review the design for our new alerting pipeline.
+```
+
+> **You:** We are adding a real-time alerting pipeline. It reads from Kafka, fans out to webhook endpoints, and retries on failure. I want to review the architecture before we start.
+>
+> **Claude:** Before we look at the design, a few things. What happens if the Kafka consumer falls behind by more than your SLA window? Is there a circuit breaker on the webhook fanout, or does one slow endpoint block the others? And when this fails at 3 AM, who gets paged and what can they do without a full rollback?
+>
+> **You:** No circuit breaker yet. On-call can restart the consumer but cannot reroute traffic.
+>
+> **Claude:** That is your first single point of failure. A slow webhook will block the entire fanout. Isolate each destination in its own worker pool before this goes to production. You also need a runbook that does not require a deploy to mitigate. Let's work through the rest.
+
+You get the gaps before any code exists. That is cheaper to fix now than after the first incident.
+
+---
+
+## 3. Build: Developing a feature
+
+**Context:** The architecture is signed off. You are implementing the webhook fanout logic.
+
+```
+Use sbp-feature-development to build the webhook fanout component.
+```
+
+The skill drives you through a TDD approach: write a failing test for the happy path first, then retry logic, then the circuit breaker. When the implementation is taking shape, switch to a security review:
+
+```
+Use sbp-secure-code-review on the webhook handler.
+```
+
+> **Claude:** The webhook URL is taken directly from the Kafka message payload and passed to the HTTP client without validation. An attacker who can write to the Kafka topic can make your service send requests to internal endpoints. Validate the URL against an allowlist of known destinations before any outbound request.
+
+That finding came from the review, not from you remembering to check for SSRF. The skill catches the class of bug, not just the instance.
+
+---
+
+## 4. Run: Deploying safely
+
+**Context:** The fanout component is ready and tested. It is Tuesday morning. You want a clean deploy.
+
+```
+Use sbp-deploy-checklist for the alerting pipeline deployment.
+```
+
+> **Claude:** Checking deployment readiness.
+>
+> **Rollback:** your deployment disables the feature flag and stops the new consumer. Rollback time is under 5 minutes. Good.
+>
+> **Monitoring:** no alert on fanout lag or dead-letter queue depth. If the fanout silently falls behind, you will not know until a customer tells you. Add those two metrics before deploying.
+>
+> **Communication:** has the on-call been notified? This component adds a new failure mode to the alerting path.
+>
+> **NO-GO** until the monitoring gaps are closed.
+
+Add the metrics, notify on-call, run the checklist again.
+
+---
+
+## 5. Run: After something breaks
+
+**Context:** Three weeks later, alert fanout silently dropped messages for two hours. The incident is over. Time to learn from it.
+
+```
+Use sbp-incident-review to run the post-incident review for the fanout outage.
+```
+
+The skill walks you through a blameless timeline and 5 whys. It does not let you stop at "the webhook timed out." It pushes until you find why the timeout was not caught by monitoring, why the retry logic did not surface the error, and what let a deployment go out without testing that failure mode.
+
+The output is a structured report with action items, owners, and deadlines, ready to share with the team.
+
+---
+
+## What's next
+
+Run `sbp-skills list` to browse everything available, or look through the `skills/` directory in this repo. If you find a workflow that is not covered, scaffold a new skill with:
+
+```bash
+sbp-skills dev --skill sbp-your-skill-name
+```
+
+Then open a PR.

--- a/WHY.md
+++ b/WHY.md
@@ -48,9 +48,9 @@ The agent challenges before you've written a line. "What's the blast radius? Who
 | | |
 |---|---|
 | `/challenge` | Stress-test your approach |
-| `architecture-review` | Single points of failure, observability, operational readiness |
-| `threat-model` | Attack surfaces, mitigations, risk matrix |
-| `agent-architecture-review` | Multi-agent system design against the three-layer model |
+| `sbp-architecture-review` | Single points of failure, observability, operational readiness |
+| `sbp-threat-model` | Attack surfaces, mitigations, risk matrix |
+| `sbp-agent-architecture-review` | Multi-agent system design against the three-layer model |
 
 ### Build
 
@@ -60,10 +60,10 @@ The agent auto-reviews its own output — silent failures, missing error handlin
 |---|---|
 | `/review` | Mission-critical review of current work |
 | `/explain` | Understand unfamiliar code or infrastructure |
-| `secure-code-review` | Security-focused analysis: auth, injection, secrets, dependencies |
-| `dependency-audit` | Supply-chain risk, bloat, unused packages |
-| `explain-codebase` | Deep dive into architecture, patterns, design decisions |
-| `why-we-do-this` | The reasoning behind SBP conventions |
+| `sbp-secure-code-review` | Security-focused analysis: auth, injection, secrets, dependencies |
+| `sbp-dependency-audit` | Supply-chain risk, bloat, unused packages |
+| `sbp-explain-codebase` | Deep dive into architecture, patterns, design decisions |
+| `sbp-why-we-do-this` | The reasoning behind SBP conventions |
 
 ### Run
 
@@ -74,11 +74,11 @@ The same team that builds it runs it. The agent thinks about what happens after 
 | `/pre-deploy` | Quick GO/NO-GO |
 | `/what-if-this-fails` | Failure cascades, recovery, the 3 AM test |
 | `/risk-check` | Full blast radius and rollback analysis |
-| `deploy-checklist` | Complete pre-deployment verification |
-| `safe-change` | Guided walkthrough for high-risk production changes |
-| `incident-review` | Blameless post-incident analysis |
-| `runbook-author` | Generate operational runbooks from the codebase |
-| `observability-check` | Verify monitoring, alerting, and logging coverage |
+| `sbp-deploy-checklist` | Complete pre-deployment verification |
+| `sbp-safe-change` | Guided walkthrough for high-risk production changes |
+| `sbp-incident-review` | Blameless post-incident analysis |
+| `sbp-runbook-author` | Generate operational runbooks from the codebase |
+| `sbp-observability-check` | Verify monitoring, alerting, and logging coverage |
 
 ### Learn
 
@@ -87,8 +87,8 @@ When you're new to a team, a codebase, or SBP itself — the agent is your onboa
 | | |
 |---|---|
 | `/explain` | Quick orientation on unfamiliar code or infra |
-| `explain-codebase` | Deep dive — data flow, patterns, design decisions |
-| `why-we-do-this` | The reasoning behind SBP conventions |
+| `sbp-explain-codebase` | Deep dive — data flow, patterns, design decisions |
+| `sbp-why-we-do-this` | The reasoning behind SBP conventions |
 
 ### Contribute
 

--- a/baseline/CLAUDE.md
+++ b/baseline/CLAUDE.md
@@ -15,6 +15,6 @@ For contributors: `/new-pack` and `/new-skill` scaffold new content.
 
 ## Skills
 
-Default skills (always linked): `architecture-review`, `deploy-checklist`.
+Default skills (always linked): `sbp-architecture-review`, `sbp-deploy-checklist`.
 
 Run `sbp-skills list` to see all available skills. Engineers enable more with `sbp-skills enable <name>` or by copying from `skills/` to `~/.claude/skills/`.

--- a/baseline/commands/new-skill.md
+++ b/baseline/commands/new-skill.md
@@ -2,12 +2,12 @@ Scaffold a new skill for sbp-skills.
 
 ## Usage
 
-Provide the skill name (lowercase-with-hyphens):
+Provide the skill name. All SBP skills use the `sbp-` prefix so they are easy to distinguish from community or personal skills:
 
 ```
-/new-skill runbook-author
-/new-skill capacity-planning
-/new-skill cost-analysis
+/new-skill sbp-runbook-author
+/new-skill sbp-capacity-planning
+/new-skill sbp-cost-analysis
 ```
 
 ## What to do

--- a/baseline/commands/new-skill.md
+++ b/baseline/commands/new-skill.md
@@ -5,8 +5,8 @@ Scaffold a new skill for sbp-skills.
 Provide the skill name. All SBP skills use the `sbp-` prefix so they are easy to distinguish from community or personal skills:
 
 ```
-/new-skill sbp-runbook-author
 /new-skill sbp-capacity-planning
+/new-skill sbp-decision-record
 /new-skill sbp-cost-analysis
 ```
 

--- a/baseline/commands/pre-deploy.md
+++ b/baseline/commands/pre-deploy.md
@@ -13,4 +13,4 @@ Answer each question concisely. Skip items that clearly don't apply (say why).
 
 Based on the answers: **GO** or **NO-GO** with the blocking reason.
 
-Keep this fast — if deeper analysis is needed, use the `deploy-checklist` skill instead.
+Keep this fast — if deeper analysis is needed, use the `sbp-deploy-checklist` skill instead.

--- a/cli/sbp-skills
+++ b/cli/sbp-skills
@@ -113,15 +113,29 @@ TOOL_DIRS = {
 }
 
 
+def claude_dir(home: Path) -> Path:
+    """Return the Claude config directory, honouring CLAUDE_CONFIG_DIR if set."""
+    env = os.environ.get("CLAUDE_CONFIG_DIR", "").strip()
+    return Path(env).expanduser() if env else home / ".claude"
+
+
 def detect_tools(home: Path) -> dict:
     """Detect installed AI coding tools by checking for config directories."""
     found = {}
+    _claude_dir = claude_dir(home)
     for tool_name, info in TOOL_DIRS.items():
-        marker = home / info["marker"]
+        if tool_name == "claude-code":
+            marker = _claude_dir
+            skills_dir = _claude_dir / "skills" if info["skills_dir"] else None
+            commands_dir = _claude_dir / "commands" if info["commands_dir"] else None
+        else:
+            marker = home / info["marker"]
+            skills_dir = home / info["skills_dir"] if info["skills_dir"] else None
+            commands_dir = home / info["commands_dir"] if info["commands_dir"] else None
         if marker.is_dir():
             found[tool_name] = {
-                "skills_dir": home / info["skills_dir"] if info["skills_dir"] else None,
-                "commands_dir": home / info["commands_dir"] if info["commands_dir"] else None,
+                "skills_dir": skills_dir,
+                "commands_dir": commands_dir,
                 "agent_file": info["agent_file"],
             }
     return found

--- a/defaults.toml
+++ b/defaults.toml
@@ -1,5 +1,5 @@
 [skills]
-default = ["architecture-review", "deploy-checklist"]
+default = ["sbp-architecture-review", "sbp-deploy-checklist"]
 
 [commands]
 # Daily use — every engineer gets these

--- a/docs/superpowers/specs/2026-05-05-howto-design.md
+++ b/docs/superpowers/specs/2026-05-05-howto-design.md
@@ -1,0 +1,31 @@
+# HOWTO.md — Design Spec
+
+**Date:** 2026-05-05
+**Status:** Approved
+
+## Goal
+
+A practical guide that shows an existing SBP engineer (Claude Code user, not yet using sbp-skills) how skills change their daily workflow — from install to real use across the engineering lifecycle.
+
+## Audience
+
+Primary: SBP engineers who already use Claude Code. Assume they know what Claude Code is; minimal explanation of skills.
+
+## Format
+
+Hybrid: short install section + 5 lifecycle scenarios, each with a one-line context and a realistic conversation snippet showing the skill in action.
+
+## Sections
+
+1. **Install** — plugin marketplace path only (`/plugin marketplace add schubergphilis/agents.md`, install skill groups, verify with one prompt)
+2. **Plan: Designing a new system** — `sbp-architecture-review` on a new alerting pipeline; agent probes blast radius, rollback, observability
+3. **Build: Developing a feature safely** — `sbp-feature-development` for TDD thinking, `sbp-secure-code-review` catching a webhook injection risk
+4. **Run: Deploying safely** — `sbp-deploy-checklist` walking rollback readiness and monitoring; agent issues GO or asks a hard question
+5. **Run: After something breaks** — `sbp-incident-review` running blameless timeline, 5 whys, concrete action items
+6. **Closing** — two sentences pointing to more skills and contribution
+
+## Constraints
+
+- Conversation snippets: realistic, not generic — use the alerting pipeline scenario throughout for coherence
+- Tone: matches WHY.md — direct, SBP-opinionated, no fluff
+- Length: ~400–600 words total; scannable

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,7 @@ DEFAULT_REPO="https://github.com/schubergphilis/agents.md.git"
 REPO_URL="${SBP_SKILLS_REPO:-$DEFAULT_REPO}"
 INSTALL_DIR="${HOME}/.local/bin"
 CACHE_DIR="${HOME}/.cache/sbp-skills"
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
 
 echo "Installing sbp-skills..."
 
@@ -64,4 +65,5 @@ if ! echo "$PATH" | tr ':' '\n' | grep -q "$INSTALL_DIR"; then
 fi
 
 echo "Installed sbp-skills to $INSTALL_DIR/sbp-skills"
+echo "Claude config dir: $CLAUDE_DIR"
 echo "Run 'sbp-skills init' in your project to get started."


### PR DESCRIPTION
## Summary

- `install.sh` now resolves `CLAUDE_DIR` from `CLAUDE_CONFIG_DIR` if set, falling back to `~/.claude`
- CLI `detect_tools` uses a new `claude_dir()` helper that applies the same logic — so skill linking and tool detection use the correct directory when the env var is present

## Usage

```bash
CLAUDE_CONFIG_DIR=/custom/path/claude sbp-skills init
```

## Test plan

- [ ] Run `sbp-skills init` without `CLAUDE_CONFIG_DIR` — skills link to `~/.claude/skills/` as before
- [ ] Run with `CLAUDE_CONFIG_DIR=/tmp/test-claude sbp-skills init` — skills link to `/tmp/test-claude/skills/`