### PR TITLE
fix: update tests and defaults.toml to use sbp- skill name prefix

### DIFF
--- a/defaults.toml
+++ b/defaults.toml
@@ -1,5 +1,5 @@
 [skills]
-default = ["architecture-review", "deploy-checklist"]
+default = ["sbp-architecture-review", "sbp-deploy-checklist"]
 
 [commands]
 # Daily use — every engineer gets these

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -23,10 +23,10 @@ def test_link_skills_replaces_existing_symlink(tmp_home, repo_root):
     skills_dir = tmp_home / ".claude" / "skills"
     skills_dir.mkdir(parents=True)
     # Create a stale symlink
-    stale = skills_dir / "architecture-review"
+    stale = skills_dir / "sbp-architecture-review"
     stale.symlink_to("/nonexistent/path")
 
-    cli.link_skills(tmp_home, repo_root, ["architecture-review"], "claude-code")
+    cli.link_skills(tmp_home, repo_root, ["sbp-architecture-review"], "claude-code")
     assert stale.is_symlink()
     assert (stale / "SKILL.md").exists()
 
@@ -36,11 +36,11 @@ def test_link_skills_replaces_existing_directory(tmp_home, repo_root):
     skills_dir = tmp_home / ".claude" / "skills"
     skills_dir.mkdir(parents=True)
     # Create a real directory where the symlink should go
-    existing = skills_dir / "architecture-review"
+    existing = skills_dir / "sbp-architecture-review"
     existing.mkdir()
     (existing / "old-file.txt").write_text("stale")
 
-    cli.link_skills(tmp_home, repo_root, ["architecture-review"], "claude-code")
+    cli.link_skills(tmp_home, repo_root, ["sbp-architecture-review"], "claude-code")
     assert existing.is_symlink()
     assert (existing / "SKILL.md").exists()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,7 +11,7 @@ def test_parse_detection_toml(repo_root):
 
 def test_parse_defaults_toml(repo_root):
     defaults = cli.parse_defaults_toml(repo_root / "defaults.toml")
-    assert "architecture-review" in defaults["skills"]
+    assert "sbp-architecture-review" in defaults["skills"]
     assert "review" in defaults["commands"]
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -66,14 +66,14 @@ def test_link_skills(tmp_home, repo_root):
     cli.link_skills(
         home=tmp_home,
         repo_root=repo_root,
-        skills=["architecture-review", "deploy-checklist"],
+        skills=["sbp-architecture-review", "sbp-deploy-checklist"],
         tool="claude-code",
     )
 
     skills_dir = tmp_home / ".claude" / "skills"
-    assert (skills_dir / "architecture-review").is_symlink()
-    assert (skills_dir / "deploy-checklist").is_symlink()
-    assert (skills_dir / "architecture-review" / "SKILL.md").exists()
+    assert (skills_dir / "sbp-architecture-review").is_symlink()
+    assert (skills_dir / "sbp-deploy-checklist").is_symlink()
+    assert (skills_dir / "sbp-architecture-review" / "SKILL.md").exists()
 
 
 def test_copy_copilot_prompts(tmp_project, repo_root):

--- a/tests/test_skill_parse.py
+++ b/tests/test_skill_parse.py
@@ -31,10 +31,10 @@ def test_parse_skill_md_missing_frontmatter():
 
 
 def test_parse_skill_md_from_file(repo_root):
-    path = repo_root / "skills" / "architecture-review" / "SKILL.md"
+    path = repo_root / "skills" / "sbp-architecture-review" / "SKILL.md"
     content = path.read_text()
     skill = cli.parse_skill_md(content)
-    assert skill["name"] == "architecture-review"
+    assert skill["name"] == "sbp-architecture-review"
     assert len(skill["description"]) >= 50
     assert skill["metadata"]["lifecycle"] == "plan"
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -25,7 +25,7 @@ def test_validate_pack_missing_agents_md(tmp_path):
 
 
 def test_validate_valid_skill(repo_root):
-    errors = cli.validate_skill(repo_root / "skills" / "architecture-review")
+    errors = cli.validate_skill(repo_root / "skills" / "sbp-architecture-review")
     assert errors == [], f"Unexpected errors: {errors}"
 
 


### PR DESCRIPTION
## Summary

- Updates all test references from old skill names (`architecture-review`, `deploy-checklist`) to the `sbp-` prefixed names
- Also fixes `defaults.toml` default skills list which was missed in the v1.0.0 rename

## Test plan

- [ ] All 52 tests pass locally