### PR TITLE
docs: safer install one-liner with download, review, and confirm

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,14 @@ Works with **Claude Code**, **GitHub Copilot**, and **OpenCode**. Compatible wit
 
 ### Option A: One-liner install
 
+> **Security note:** Piping directly to `bash` executes remote code without review. Download first, inspect, then run.
+
 ```bash
-curl -sSL https://raw.githubusercontent.com/schubergphilis/agents.md/main/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/schubergphilis/agents.md/main/install.sh -o /tmp/sbp-install.sh \
+  && cat /tmp/sbp-install.sh \
+  && printf '\nInstall sbp-skills? [y/N] ' \
+  && read -r yn \
+  && [[ $yn =~ ^[yY]$ ]] && bash /tmp/sbp-install.sh || echo "Aborted."
 ```
 
 Then in any project:


### PR DESCRIPTION
## Summary

- Replaces `curl | bash` with a download-first pattern that writes to `/tmp/sbp-install.sh`
- Displays the script content for review before execution
- Prompts the user for explicit `[y/N]` confirmation before running
- Uses `printf` + `read -r` instead of `read -rp` for cross-shell compatibility (bash and zsh / macOS default)

## Test plan

- [ ] Run the one-liner on macOS (zsh) — verify prompt appears and `y` installs, `N` prints "Aborted."
- [ ] Run on Linux (bash) — same verification
- [ ] Verify the script is visible in `/tmp/sbp-install.sh` for manual inspection