### PR TITLE
docs: rewrite skill descriptions to 'Use when' trigger pattern

### DIFF
--- a/skills/sbp-brandbook/SKILL.md
+++ b/skills/sbp-brandbook/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sbp-brandbook
-description: Apply the Schuberg Philis visual brand identity when building any UI, HTML component, slide, document, or design asset for SBP. Use whenever output will represent SBP visually — colors, typography, logo, stylization, grids, photography, iconography. Ensures brand-consistent output without manual reminders.
+description: Use when building any UI, HTML component, slide, document, or design asset that will represent SBP visually — applies the Schuberg Philis visual brand identity (colors, typography, logo, stylization, grids, photography, iconography) to ensure brand-consistent output without manual reminders.
 metadata:
   domain: brand
   lifecycle: build

--- a/skills/sbp-dependency-audit/SKILL.md
+++ b/skills/sbp-dependency-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sbp-dependency-audit
-description: Analyze project dependencies for bloat, supply-chain risk, and maintainability — classify each dependency, flag security concerns, identify unused or trivially replaceable packages, and produce a prioritized action plan. Use during security reviews or when reducing dependency surface.
+description: Use when conducting a security review, reducing dependency surface, or when dependencies may pose supply-chain, bloat, or maintainability risks.
 metadata:
   domain: security
   lifecycle: build

--- a/skills/sbp-deploy-checklist/SKILL.md
+++ b/skills/sbp-deploy-checklist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sbp-deploy-checklist
-description: Pre-deployment verification against mission-critical criteria — rollback readiness, monitoring, change communication, and go/no-go decision. Use before any production deployment.
+description: Use when deploying to production — verifies rollback readiness, monitoring, and change communication against mission-critical criteria and produces a go/no-go decision.
 metadata:
   domain: platform
   lifecycle: run

--- a/skills/sbp-incident-review/SKILL.md
+++ b/skills/sbp-incident-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sbp-incident-review
-description: Structured post-incident analysis — reconstruct timeline, assess impact, find root causes and contributing factors, capture what went well, and produce concrete action items. Blameless throughout. Use after any production incident.
+description: Use when a production incident has occurred — structured blameless post-incident analysis that reconstructs timeline, assesses impact, finds root causes, and produces concrete action items.
 metadata:
   domain: platform
   lifecycle: run

--- a/skills/sbp-observability-check/SKILL.md
+++ b/skills/sbp-observability-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sbp-observability-check
-description: Verify monitoring, alerting, and logging coverage across the four pillars — metrics, logs, traces, and alerts. Produces a coverage matrix with gaps, severity ratings, and recommended actions. Applies the 3 AM test to every component.
+description: Use when verifying monitoring, alerting, and logging coverage — checks the four pillars (metrics, logs, traces, alerts), produces a coverage matrix with gaps, severity ratings, and recommended actions, and applies the 3 AM test to every component.
 metadata:
   domain: platform
   lifecycle: run

--- a/skills/sbp-refactor/SKILL.md
+++ b/skills/sbp-refactor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sbp-refactor
-description: Improve code structure, readability, or maintainability without changing observable behavior — establish a safety net, plan small reversible steps, execute iteratively, and validate no regressions. Use before a feature needs existing code to change shape, or when code has drifted into a state that makes further work expensive.
+description: Use when existing code needs to change shape before a feature, or when code drift is making further work expensive — improves structure and readability without changing observable behavior.
 metadata:
   domain: cross-cutting
   lifecycle: build

--- a/skills/sbp-runbook-author/SKILL.md
+++ b/skills/sbp-runbook-author/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sbp-runbook-author
-description: Generate operational runbooks from code and infrastructure that work at 3 AM when the on-call engineer is half-awake. Covers common failure scenarios with specific diagnosis and resolution steps, copy-pasteable commands, and clear escalation paths.
+description: Use when generating operational runbooks from code and infrastructure — produces runbooks that work at 3 AM, covering common failure scenarios with specific diagnosis and resolution steps, copy-pasteable commands, and clear escalation paths.
 metadata:
   domain: platform
   lifecycle: run

--- a/skills/sbp-safe-change/SKILL.md
+++ b/skills/sbp-safe-change/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sbp-safe-change
-description: Guided walkthrough for high-risk production changes — classify the change, assess risk, run pre-flight checks, build an execution plan with rollback triggers, and verify after completion. Use before any change that makes you nervous.
+description: Use when planning a high-risk production change — classifies the change, assesses risk, runs pre-flight checks, builds an execution plan with rollback triggers, and verifies after completion.
 metadata:
   domain: platform
   lifecycle: run

--- a/skills/sbp-secure-code-review/SKILL.md
+++ b/skills/sbp-secure-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sbp-secure-code-review
-description: Security-focused code review for mission-critical systems. Checks OWASP Top 10, authentication and authorization, input validation, secrets handling, dependency vulnerabilities, cryptography, and security logging. Frames findings by blast radius and customer impact.
+description: Use when reviewing code in mission-critical systems — checks OWASP Top 10, authentication and authorization, input validation, secrets handling, dependency vulnerabilities, cryptography, and security logging, framing findings by blast radius and customer impact.
 metadata:
   domain: security
   lifecycle: build

--- a/skills/sbp-test-planning/SKILL.md
+++ b/skills/sbp-test-planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sbp-test-planning
-description: Design comprehensive test coverage for a feature or change before implementation — identify behaviors, boundary cases, failure modes, and integration seams, then pick the right test type for each. Use before writing code, or before adding tests to untested code, especially in mission-critical systems where coverage gaps become incidents.
+description: Use when designing test coverage before writing code, or when adding tests to existing untested code — especially in mission-critical systems where coverage gaps become incidents.
 metadata:
   domain: cross-cutting
   lifecycle: plan

--- a/skills/sbp-threat-model/SKILL.md
+++ b/skills/sbp-threat-model/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sbp-threat-model
-description: Structured threat modeling for systems and changes — identify assets, map attack surfaces, assess risks, and produce a prioritized threat matrix with concrete mitigations. Use before design reviews or when evaluating security posture.
+description: Use when preparing for a design review or when evaluating security posture — identifies assets, maps attack surfaces, assesses risks, and produces a prioritized threat matrix with concrete mitigations.
 metadata:
   domain: security
   lifecycle: plan


### PR DESCRIPTION
## Summary

- Rewrites descriptions for 11 skills to start with a consistent `Use when` trigger phrase
- Makes it unambiguous to AI agents when each skill should be invoked
- No functional changes — description text only

## Skills updated

`sbp-brandbook`, `sbp-dependency-audit`, `sbp-deploy-checklist`, `sbp-incident-review`, `sbp-observability-check`, `sbp-refactor`, `sbp-runbook-author`, `sbp-safe-change`, `sbp-secure-code-review`, `sbp-test-planning`, `sbp-threat-model`

## Test plan

- [ ] Verify each description reads naturally as a trigger condition
- [ ] Confirm no SKILL.md frontmatter structure was altered